### PR TITLE
Fixed handling of block devices with > 512 byte sector size.

### DIFF
--- a/src/core/blockio.h
+++ b/src/core/blockio.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <string>
+#include <vector>
 
 #define BLOCKSIZE 512
 
@@ -19,4 +20,13 @@ struct source
 ssize_t readlogicalblocks(source & s,
 void * buffer,
 long long pos, long long count);
+
+template <typename T>
+ssize_t readlogicalblocks(source & s,
+std::vector<T> & buffer,
+long long pos, long long count) {
+  typedef char T_must_be_byte[sizeof(T) == 1? 1: -1];
+  buffer.resize(s.blocksize * count);
+  return readlogicalblocks(s, &buffer[0], pos, count);
+}
 #endif


### PR DESCRIPTION
This also dealt with some buffer overruns caused by assumptions of 512 byte
block size. Most likely these buffer overruns were benign as they would just
overwrite one of the many static buffers that are used only within the context
of a function, but a large enough sector size could cause it to overwrite
something more important.