### PR TITLE
added: expose modalias information for pci and net devices.

### DIFF
--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -28,7 +28,7 @@ struct hwNode_i
 {
   hwClass deviceclass;
   string id, vendor, product, version, date, serial, slot, handle, description,
-    businfo, physid, dev;
+    businfo, physid, dev, modalias;
   bool enabled;
   bool claimed;
   unsigned long long start;
@@ -121,6 +121,7 @@ const string & product, const string & version)
   This->description = string("");
   This->businfo = string("");
   This->physid = string("");
+  This->modalias = string("");
   This->dev = string("");
 }
 
@@ -1043,6 +1044,22 @@ void hwNode::setLogicalName(const string & name)
 }
 
 
+string hwNode::getModalias() const
+{
+  if (This)
+    return This->modalias;
+  else
+    return "";
+}
+
+
+void hwNode::setModalias(const string & modalias)
+{
+  if (This)
+    This->modalias = strip(modalias);
+}
+
+
 string hwNode::getDev() const
 {
   if (This)
@@ -1432,6 +1449,15 @@ string hwNode::asJSON(unsigned level)
         out << "\"" << escapeJSON(getLogicalName()) << "\"";
     }
 
+    if (getModalias() != "")
+    {
+      out << "," << endl;
+      out << spaces(2*level+2);
+      out << "\"modalias\" : \"";
+      out << escapeJSON(getModalias());
+      out << "\"";
+    }
+
     if (getDev() != "")
     {
       out << "," << endl;
@@ -1730,6 +1756,15 @@ string hwNode::asXML(unsigned level)
         out << "</logicalname>";
         out << endl;
       }
+    }
+
+    if (getModalias() != "")
+    {
+      out << spaces(2*level+1);
+      out << "<modalias>";
+      out << escape(getModalias());
+      out << "</modalias>";
+      out << endl;
     }
 
     if (getDev() != "")

--- a/src/core/hw.h
+++ b/src/core/hw.h
@@ -189,6 +189,9 @@ class hwNode
     string getLogicalName() const;
     void setLogicalName(const string &);
 
+    string getModalias() const;
+    void setModalias(const string & modalias);
+
     string getDev() const;
     void setDev(const string &);
 

--- a/src/core/network.cc
+++ b/src/core/network.cc
@@ -533,6 +533,8 @@ bool scan_network(hwNode & n)
       if(sysfs::entry::byClass("net", interface.getLogicalName()).hassubdir("bridge"))
         interface.addCapability("logical", _("Logical interface"));
 
+      interface.setModalias(sysfs_getmodalias(sysfs::entry::byClass("net", interface.getLogicalName())));
+
       existing = n.findChildByBusInfo(interface.getBusInfo());
       // Multiple NICs can exist on one PCI function.
       // Only merge if MACs also match.

--- a/src/core/pci.cc
+++ b/src/core/pci.cc
@@ -1146,6 +1146,11 @@ bool scan_pci(hwNode & n)
           device->claim();
         }
 
+        if(exists(string(devices[i]->d_name)+"/modalias")) {
+          string modalias = get_string(string(devices[i]->d_name)+"/modalias");
+          device->setModalias(modalias);
+        }
+
         if(exists(resourcename))
         {
             FILE*resource = fopen(resourcename.c_str(), "r");

--- a/src/core/sysfs.cc
+++ b/src/core/sysfs.cc
@@ -186,6 +186,33 @@ string sysfs_getbusinfo(const entry & e)
 }
 
 
+string sysfs_getmodalias(const entry & e)
+{
+  if(e.This->devclass != "") {
+    string modaliaspath =
+      fs.path + string("/class/") + e.This->devclass + string("/") + e.This->devname + "/device/modalias";
+
+    if(exists(modaliaspath)) {
+      return get_string(modaliaspath);
+    }
+
+    string ueventpath =
+      fs.path + string("/class/") + e.This->devclass + string("/") + e.This->devname + "/device/uevent";
+
+    if(exists(ueventpath)) {
+      string uevent = get_string(ueventpath);
+      size_t modalias_pos = uevent.find("MODALIAS=");
+      if (modalias_pos != string::npos) {
+        size_t modalias_pos2 = uevent.find(modalias_pos, '\n');
+        return uevent.substr(modalias_pos+9, modalias_pos2-modalias_pos+9);
+      }
+    }
+  }
+
+  return "";
+}
+
+
 static string finddevice(const string & name, const string & root = "")
 {
   struct dirent **namelist;

--- a/src/core/sysfs.h
+++ b/src/core/sysfs.h
@@ -35,5 +35,6 @@ namespace sysfs
 bool scan_sysfs(hwNode & n);
 
 std::string sysfs_getbusinfo(const sysfs::entry &);
+std::string sysfs_getmodalias(const sysfs::entry &);
 std::string sysfs_finddevice(const string &name);
 #endif


### PR DESCRIPTION
Having modalias information available provides the ability to map a device's loaded driver to it's modalias. This is an important use case in hardware driver managers.