### PR TITLE
Add pseries guest information

### DIFF
--- a/src/core/cpufreq.cc
+++ b/src/core/cpufreq.cc
@@ -59,11 +59,9 @@ bool scan_cpufreq(hwNode & node)
     snprintf(buffer, sizeof(buffer), DEVICESCPUFREQ, i);
     if(exists(buffer))
     {
-      unsigned long long max, min, cur;
+      unsigned long long max, cur;
       pushd(buffer);
 
-                                                  // in Hz
-      min = 1000*(unsigned long long)get_long("cpuinfo_min_freq");
                                                   // in Hz
       max = 1000*(unsigned long long)get_long("cpuinfo_max_freq");
                                                   // in Hz

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -729,10 +729,26 @@ bool scan_device_tree(hwNode & n)
   }
   else if(matches(get_string(DEVICETREE "/compatible"), "qemu,pseries"))
   {
+    string product;
+
     if ( exists(DEVICETREE "/host-serial") )
       n.setSerial(get_string(DEVICETREE "/host-serial"));
 
     n.setVendor(get_string(DEVICETREE "/vendor", "IBM"));
+
+    if ( exists(DEVICETREE "/hypervisor/compatible") ) {
+      product = get_string(DEVICETREE "/hypervisor/compatible");
+      product = product.substr(0, product.size()-1);
+    }
+
+    if ( exists(DEVICETREE "/host-model") ) {
+      product += " Model# ";
+      product += get_string(DEVICETREE "/host-model");
+    }
+
+    if (product != "")
+      n.setProduct(product);
+
     n.setDescription("pSeries Guest");
 
     if (core)

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -734,6 +734,9 @@ bool scan_device_tree(hwNode & n)
     if ( exists(DEVICETREE "/host-serial") )
       n.setSerial(get_string(DEVICETREE "/host-serial"));
 
+    if ( exists( DEVICETREE "/vm,uuid") )
+      n.setConfig("uuid", get_string(DEVICETREE "/vm,uuid"));
+
     n.setVendor(get_string(DEVICETREE "/vendor", "IBM"));
 
     if ( exists(DEVICETREE "/hypervisor/compatible") ) {

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -464,7 +464,6 @@ static void scan_devtree_memory(hwNode & core)
       {
         for (unsigned int i = 0; i < slotnames.size(); i++)
         {
-          uint64_t base = regs[i].address;
           uint64_t size = regs[i].size;
           hwNode bank("bank",
             hw::memory);
@@ -559,7 +558,6 @@ static void scan_devtree_memory(hwNode & core)
             bank.addHint("icon", string("memory"));
           bank.setDescription("Memory bank");
           bank.setSlot(slotnames[i]);
-//bank.setPhysId(base);
           if (i < dimmtypes.size())
             bank.setDescription(dimmtypes[i]);
           if (i < dimmspeeds.size())

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -727,6 +727,19 @@ bool scan_device_tree(hwNode & n)
       n.addCapability("opal", "OPAL firmware");
     }
   }
+  else if(matches(get_string(DEVICETREE "/compatible"), "qemu,pseries"))
+  {
+    n.setVendor(get_string(DEVICETREE "/vendor", "IBM"));
+    n.setDescription("pSeries Guest");
+
+    if (core)
+    {
+      core->addHint("icon", string("board"));
+      scan_devtree_root(*core);
+      scan_devtree_cpu(*core);
+      core->addCapability("qemu,pseries");
+    }
+  }
   else
   {
     n.setVendor(get_string(DEVICETREE "/copyright", n.getVendor()));

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -729,6 +729,9 @@ bool scan_device_tree(hwNode & n)
   }
   else if(matches(get_string(DEVICETREE "/compatible"), "qemu,pseries"))
   {
+    if ( exists(DEVICETREE "/host-serial") )
+      n.setSerial(get_string(DEVICETREE "/host-serial"));
+
     n.setVendor(get_string(DEVICETREE "/vendor", "IBM"));
     n.setDescription("pSeries Guest");
 


### PR DESCRIPTION
Please review these fixes for lshw on a VM guest when run on PowerNV. This branch is based on top of my previous pull request branch: lshw-cleanup.
I have opened ticket against these warnings at www.ezix.org (Added attachments to Moderated Submission #513)

With these set of patches we help lshw display accurate VM information.

We check if lshw is run on a guest on PowerKVM. If yes,we add host information support and information that helps us to uniquely identify a guest. Then we collect host-serial, host-model, hypervisor details and vm,uuid which is provided through qemu and exported through the device tree.

After these patches are applied, the head of output of lshw, when run on a pseries guest, will be somewhat as follows:

```
localhost
    description: pSeries Guest
    product: linux,kvm Model# 8286-42A
    vendor: IBM
    serial: 10665FT
    width: 4294967295 bits
    capabilities: smp
    configuration: uuid=e6ce4235-4db9-4dfa-a85e-01ef29b6eb70
  *-core
       description: Motherboard
       physical id: 0
       capabilities: qemu_pseries
...
```
