### PR TITLE
Cpus

### DIFF
--- a/src/core/cpufreq.cc
+++ b/src/core/cpufreq.cc
@@ -10,6 +10,7 @@
 #include "version.h"
 #include "hw.h"
 #include "osutils.h"
+#include "cpufreq.h"
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -18,10 +19,16 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <map>
+#include <iostream>
+#include <stdexcept>
 
 __ID("@(#) $Id$");
 
-#define DEVICESCPUFREQ "/sys/devices/system/cpu/cpu%d/cpufreq/"
+#define DEVICESCPU "/sys/devices/system/cpu/cpu%d"
+#define DEVICESCPUFREQ DEVICESCPU "/cpufreq/"
+
+using namespace std;
 
 static long get_long(const string & path)
 {
@@ -48,11 +55,131 @@ static string cpubusinfo(int cpu)
   return string(buffer);
 }
 
+#ifdef __powerpc__
+
+static long get_ushort(const string & path)
+{
+  unsigned short result = 0;
+  FILE * in = fopen(path.c_str(), "r");
+
+  if (in)
+  {
+    if(fscanf(in, "%hu", &result) != 1)
+      result = 0;
+    fclose(in);
+  }
+
+  return result;
+}
+
+static long get_ulong(const string & path)
+{
+  unsigned long result = 0;
+  FILE * in = fopen(path.c_str(), "r");
+
+  if (in)
+  {
+    if(fscanf(in, "%lu", &result) != 1)
+      result = 0;
+    fclose(in);
+  }
+
+  return result;
+}
+
+unsigned long long sysfsData::get_max_freq () const
+{
+  return max_freq;
+}
+
+void sysfsData::set_max_freq (unsigned long long max_freq)
+{
+  this->max_freq = max_freq;
+}
+
+unsigned long long sysfsData::get_cur_freq () const
+{
+  return cur_freq;
+}
+
+void sysfsData::set_cur_freq (unsigned long long cur_freq)
+{
+  this->cur_freq = cur_freq;
+}
+
+#endif
 
 bool scan_cpufreq(hwNode & node)
 {
+
   char buffer[PATH_MAX];
   unsigned i =0;
+
+#ifdef __powerpc__
+
+  map <unsigned long, sysfsData> core_to_data;
+  char buffer_online[PATH_MAX] = {0};
+
+  snprintf(buffer, sizeof(buffer), DEVICESCPU, i);
+
+  strcpy(buffer_online, buffer);
+  strcat(buffer_online, "/online");
+
+  while(exists(buffer))
+  {
+    if (get_ushort(buffer_online) == 1)
+    {
+      //read data and add to map
+      sysfsData data;
+      unsigned long long max, cur;
+      unsigned long core_id;
+
+      pushd(buffer);
+
+      max = 1000*(unsigned long long)get_long("cpufreq/cpuinfo_max_freq");
+      cur = 1000*(unsigned long long)get_long("cpufreq/scaling_cur_freq");
+      data.set_max_freq(max);
+      data.set_cur_freq(cur);
+
+      string buffer_coreid = string(buffer) + string("/topology/core_id");
+      if (exists(buffer_coreid))
+      {
+        core_id = get_ulong(buffer_coreid);
+        core_to_data.insert(pair<unsigned long, sysfsData>(core_id, data));
+      }
+
+      popd();
+    }
+    snprintf(buffer, sizeof(buffer), DEVICESCPU, ++i);
+  }
+
+  i=0;
+  while(hwNode *cpu = node.findChildByBusInfo(cpubusinfo(i)))
+  {
+    sysfsData data;
+    unsigned long reg;
+    try
+    {
+      unsigned long long max;
+
+      reg = cpu->getReg();
+      data = core_to_data.at(reg);
+      core_to_data.erase(reg);//Erase for making next searches faster
+      cpu->addCapability("cpufreq", "CPU Frequency scaling");
+      cpu->setSize(data.get_cur_freq());
+      max = data.get_max_freq();
+      if(max>cpu->getCapacity())
+        cpu->setCapacity(max);
+    }
+    catch(const out_of_range& oor)
+    {
+      cerr<<"key ("<<reg<<") not an element of the core-to-sysfs-data map: ";
+      cerr<<oor.what()<<endl;
+    }
+    i++;
+  }
+
+#else
 
   while(hwNode * cpu = node.findChildByBusInfo(cpubusinfo(i)))
   {
@@ -73,6 +200,8 @@ bool scan_cpufreq(hwNode & node)
     }
     i++;
   }
+
+#endif  //__powerpc__
 
   return true;
 }

--- a/src/core/cpufreq.h
+++ b/src/core/cpufreq.h
@@ -3,5 +3,20 @@
 
 #include "hw.h"
 
+#ifdef __powerpc__
+class sysfsData
+{
+  unsigned long long max_freq;
+  unsigned long long cur_freq;
+
+public:
+  unsigned long long get_max_freq () const;
+  void set_max_freq (unsigned long long max_freq);
+
+  unsigned long long get_cur_freq () const;
+  void set_cur_freq (unsigned long long cur_freq);
+};
+#endif //__powerpc__
+
 bool scan_cpufreq(hwNode & n);
 #endif

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -565,6 +565,7 @@ static void scan_devtree_cpu_power(hwNode & core)
     }
 
     set_cpu(cpu, currentcpu++, basepath);
+    cpu.setReg(get_u32(basepath + "/reg"));
 
     version = get_u32(basepath + "/cpu-version");
     if (version != 0)

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -1042,8 +1042,8 @@ bool scan_device_tree(hwNode & n)
     {
       core->addHint("icon", string("board"));
       scan_devtree_root(*core);
-      scan_devtree_memory_powernv(*core);
       scan_devtree_cpu_power(*core);
+      scan_devtree_memory_powernv(*core);
       n.addCapability("powernv", "Non-virtualized");
       n.addCapability("opal", "OPAL firmware");
     }
@@ -1092,8 +1092,6 @@ bool scan_device_tree(hwNode & n)
     {
       core->addHint("icon", string("board"));
       scan_devtree_root(*core);
-      scan_devtree_bootrom(*core);
-      scan_devtree_memory(*core);
       if (exists(DEVICETREE "/ibm,lpar-capable"))
       {
         n.setDescription("pSeries LPAR");
@@ -1101,6 +1099,8 @@ bool scan_device_tree(hwNode & n)
       }
       else
         scan_devtree_cpu(*core);
+      scan_devtree_bootrom(*core);
+      scan_devtree_memory(*core);
     }
   }
 

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -1036,6 +1036,7 @@ bool scan_device_tree(hwNode & n)
   {
     n.setVendor(get_string(DEVICETREE "/vendor", "IBM"));
     n.setProduct(get_string(DEVICETREE "/model-name"));
+    n.setDescription("PowerNV");
     if (core)
     {
       core->addHint("icon", string("board"));
@@ -1093,7 +1094,10 @@ bool scan_device_tree(hwNode & n)
       scan_devtree_bootrom(*core);
       scan_devtree_memory(*core);
       if (exists(DEVICETREE "/ibm,lpar-capable"))
+      {
+        n.setDescription("pSeries LPAR");
         scan_devtree_cpu_power(*core);
+      }
       else
         scan_devtree_cpu(*core);
     }

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <utility>
+#include <map>
 
 __ID("@(#) $Id$");
 
@@ -340,6 +342,183 @@ static void scan_devtree_cpu(hwNode & core)
     }
     free(namelist);
   }
+}
+
+
+static void scan_devtree_cpu_power(hwNode & core)
+{
+  struct dirent **namelist;
+  int n;
+  int currentcpu=0;
+  map <unsigned long, pair<unsigned long, vector <hwNode> > > l2_caches;
+  map <unsigned long, vector <hwNode> > l3_caches;
+
+  pushd(DEVICETREE "/cpus");
+  n = scandir(".", &namelist, selectdir, alphasort);
+  popd();
+  if (n < 0)
+    return;
+
+  for (int i = 0; i < n; i++) //first pass
+  {
+    string basepath =
+      string(DEVICETREE "/cpus/") + string(namelist[i]->d_name);
+    hwNode cache("cache",
+      hw::memory);
+    vector <hwNode> value;
+
+    if (exists(basepath + "/device_type") &&
+      hw::strip(get_string(basepath + "/device_type")) != "cache")
+      continue;                                    // oops, not a cache!
+
+    cache.claim();
+    cache.setProduct(get_string(basepath + "/name"));
+    if (cache.getProduct () == "l2-cache")
+      cache.setDescription("L2 Cache");
+    else
+      cache.setDescription("L3 Cache");
+
+    if (hw::strip(get_string(basepath + "/status")) != "okay")
+      cache.disable();
+
+    cache.setSize(get_u32(basepath + "/d-cache-size"));
+
+    if (exists(basepath + "/cache-unified"))
+      cache.setDescription(cache.getDescription() + " (unified)");
+    else
+    {
+      hwNode icache = cache;
+      icache.claim();
+      cache.setDescription(cache.getDescription() + " (data)");
+      icache.setDescription(icache.getDescription() + " (instruction)");
+      icache.setSize(get_u32(basepath + "/i-cache-size"));
+      if (cache.disabled())
+        icache.disable();
+
+      if (icache.getSize() > 0)
+        value.push_back(icache);
+    }
+
+    if (cache.getSize() > 0)
+    {
+      value.insert(value.begin(), cache);
+    }
+
+    if (value.size() > 0)
+    {
+      unsigned long phandle = 0;
+      if (exists(basepath + "/phandle"))
+        phandle = get_u32(basepath + "/phandle");
+      else if (exists(basepath + "/ibm,phandle"))
+        phandle = get_u32(basepath + "/ibm,phandle");
+
+      if (phandle)
+      {
+        if (cache.getProduct () == "l2-cache")
+        {
+          unsigned long l3_key = 0; // 0 indicating no next level of cache
+          if (exists(basepath + "/l2-cache"))
+            l3_key = get_u32(basepath + "/l2-cache");
+          else if (exists(basepath + "/next-level-cache")) //on OpenPOWER systems
+            l3_key = get_u32(basepath + "/next-level-cache");
+
+          pair <unsigned long, vector <hwNode> > p (l3_key, value);
+          l2_caches[phandle] = p;
+        }
+        else if (cache.getProduct () == "l3-cache")
+        {
+          l3_caches[phandle] = value;
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < n; i++) //second and final pass
+  {
+    string basepath =
+      string(DEVICETREE "/cpus/") + string(namelist[i]->d_name);
+    unsigned long version = 0;
+    hwNode cpu("cpu",
+      hw::processor);
+
+    if (exists(basepath + "/device_type") &&
+      hw::strip(get_string(basepath + "/device_type")) != "cpu")
+    {
+      free(namelist[i]);
+      continue;                                    // oops, not a CPU!
+    }
+
+    set_cpu(cpu, currentcpu++, basepath);
+
+    version = get_u32(basepath + "/cpu-version");
+    if (version != 0)
+    {
+      char buffer[20];
+
+      snprintf(buffer, sizeof(buffer), "%08lx", version);
+      cpu.setVersion(buffer);
+    }
+
+    if (hw::strip(get_string(basepath + "/status")) != "okay")
+      cpu.disable();
+
+    if (exists(basepath + "/d-cache-size"))
+    {
+      hwNode cache("cache",
+        hw::memory);
+      hwNode icache("cache",
+        hw::memory);
+
+      cache.claim();
+      cache.setDescription("L1 Cache");
+      cache.setSize(get_u32(basepath + "/d-cache-size"));
+
+      if (exists(basepath + "/cache-unified"))
+        cache.setDescription(cache.getDescription() + " (unified)");
+      else
+      {
+        cache.setDescription(cache.getDescription() + " (data)");
+
+        icache.claim();
+        icache.setDescription("L1 Cache (instruction)");
+        icache.setSize(get_u32(basepath + "/i-cache-size"));
+      }
+
+      if (cache.getSize() > 0)
+        cpu.addChild(cache);
+
+      if (icache.getSize() > 0)
+        cpu.addChild(icache);
+    }
+
+    if (exists(basepath + "/l2-cache") || exists(basepath + "/next-level-cache"))
+    {
+      unsigned long l2_key = (unsigned long) get_u32(basepath + "/l2-cache");
+      if (l2_key == 0)
+	      l2_key = get_u32(basepath + "/next-level-cache");
+      map <unsigned long, pair <unsigned long, vector <hwNode> > >::
+        const_iterator got = l2_caches.find(l2_key);
+
+      if (!(got == l2_caches.end()))
+        for (unsigned int j=0; j<(got->second).second.size(); j++)
+        cpu.addChild((got->second).second[j]);
+
+      if ((got->second).first != 0) //we have another level of cache
+      {
+        map <unsigned long, vector <hwNode> >::const_iterator got_l3 =
+          l3_caches.find ((got->second).first);
+
+        if (!(got_l3 == l3_caches.end()))
+          for (unsigned int j=0; j<(got_l3->second).size(); j++)
+            cpu.addChild((got_l3->second)[j]);
+      }
+    }
+
+    core.addChild(cpu);
+
+    free(namelist[i]);
+  }
+  free(namelist);
 }
 
 void add_memory_bank(string name, string path, hwNode & core)
@@ -728,7 +907,7 @@ bool scan_device_tree(hwNode & n)
       core->addHint("icon", string("board"));
       scan_devtree_root(*core);
       scan_devtree_memory_powernv(*core);
-      scan_devtree_cpu(*core);
+      scan_devtree_cpu_power(*core);
       n.addCapability("powernv", "Non-virtualized");
       n.addCapability("opal", "OPAL firmware");
     }
@@ -764,7 +943,7 @@ bool scan_device_tree(hwNode & n)
     {
       core->addHint("icon", string("board"));
       scan_devtree_root(*core);
-      scan_devtree_cpu(*core);
+      scan_devtree_cpu_power(*core);
       core->addCapability("qemu", "QEMU virtualization");
       core->addCapability("guest", "Virtualization guest");
     }
@@ -779,7 +958,10 @@ bool scan_device_tree(hwNode & n)
       scan_devtree_root(*core);
       scan_devtree_bootrom(*core);
       scan_devtree_memory(*core);
-      scan_devtree_cpu(*core);
+      if (exists(DEVICETREE "/ibm,lpar-capable"))
+        scan_devtree_cpu_power(*core);
+      else
+        scan_devtree_cpu(*core);
     }
   }
 

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -426,6 +426,36 @@ static void scan_chip_level_vpd(map <unsigned long, processor_vpd_data *> & vpd)
 }
 
 
+static void set_cpu_config_threads(hwNode & cpu, const string & basepath)
+{
+  static bool first_cpu_in_system = true;
+  static int threads_per_cpu;
+
+  /* In power systems, there are equal no. of threads per cpu-core */
+  if(first_cpu_in_system)
+  {
+    struct stat sbuf;
+    string p = basepath + string("/ibm,ppc-interrupt-server#s");
+    char path[128];
+    int rc;
+
+    strcpy(path, p.c_str());
+    rc = stat(path, &sbuf);
+    if (!rc)
+      /*
+       * This file contains as many 32 bit interrupt server numbers, as the
+       * number of threads per CPU (in hexadecimal format). st_size gives size
+       * in bytes of a file. Hence, grouping by 4 bytes, we get the thread
+       * count.
+       */
+      threads_per_cpu = sbuf.st_size / 4;
+    first_cpu_in_system = false;
+  }
+
+  cpu.setConfig("threads", threads_per_cpu);
+}
+
+
 static void scan_devtree_cpu_power(hwNode & core)
 {
   struct dirent **namelist;
@@ -560,6 +590,8 @@ static void scan_devtree_cpu_power(hwNode & core)
 
     if (hw::strip(get_string(basepath + "/status")) != "okay")
       cpu.disable();
+
+    set_cpu_config_threads(cpu, basepath);
 
     if (exists(basepath + "/d-cache-size"))
     {

--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -35,6 +35,7 @@ struct hwNode_i
   unsigned long long size;
   unsigned long long capacity;
   unsigned long long clock;
+  unsigned long reg; //for internal reference from cpufreq module for powerpc
   unsigned int width;
   vector < hwNode > children;
   vector < string > attracted;
@@ -114,6 +115,7 @@ const string & product, const string & version)
   This->size = 0;
   This->capacity = 0;
   This->clock = 0;
+  This->reg = 0;
   This->width = 0;
   This->enabled = true;
   This->claimed = false;
@@ -539,6 +541,22 @@ void hwNode::setClock(unsigned long long clock)
 {
   if (This)
     This->clock = clock;
+}
+
+
+unsigned long hwNode::getReg() const
+{
+  if (This)
+    return This->reg;
+  else
+    return 0;
+}
+
+
+void hwNode::setReg(unsigned long reg)
+{
+  if (This)
+    This->reg = reg;
 }
 
 
@@ -1224,6 +1242,8 @@ void hwNode::merge(const hwNode & node)
     This->capacity = node.getCapacity();
   if (This->clock == 0)
     This->clock = node.getClock();
+  if (This->reg == 0)
+    This->reg = node.getReg();
   if (This->width == 0)
     This->width = node.getWidth();
   if (node.enabled())

--- a/src/core/hw.h
+++ b/src/core/hw.h
@@ -148,6 +148,9 @@ class hwNode
     unsigned long long getClock() const;
     void setClock(unsigned long long clock);
 
+    unsigned long getReg() const;
+    void setReg(unsigned long reg);
+
     unsigned int getWidth() const;
     void setWidth(unsigned int width);
 


### PR DESCRIPTION
Please look into this patch set. The reference moderated submission number on ezix.org is #514.
This work has been rebased on top of current lshw master.

Major works in this patch set include:

-Compliance of lshw cpu nodes on FSP and BMC based powernv

-Compliance of lshw cpu nodes on FSP and BMC based pseries guest

-Compliance of lshw cpu nodes on pseries LPARs

-Removal of SMT thread representing nodes and making sure correct cpu-frequencies get displayed against corresponding cores


After applying these patches we see the following output snippets on powerpc:


On PowerNV (with latest firmware):
```
tul176p1
    description: PowerNV
    product: IBM Power System S824
    vendor: IBM
    serial: 10665FT
    width: 4294967295 bits
    capabilities: smp powernv opal
  *-core
       description: Motherboard
       physical id: 0
     *-cpu:0
          description: CPU
          product: POWER8E (raw), altivec supported Part#00FY143 FRU#00FX519
          physical id: 0
          bus info: cpu@0
          version: 2.0 (pvr 004b 0200)
          serial: YA3932008163
          slot: U78C9.001.RST0027-P1-C32
          size: 3724MHz
          capacity: 4123MHz
          capabilities: performance-monitor cpufreq
          configuration: threads=8
        *-cache:0
             description: L1 Cache (data)
             physical id: 0
             size: 64KiB
        *-cache:1
             description: L1 Cache (instruction)
             physical id: 1
             size: 32KiB
        *-cache:2
             description: L2 Cache (unified)
             product: l2-cache
             physical id: 2
             size: 512KiB
        *-cache:3
             description: L3 Cache (unified)
             product: l3-cache
             physical id: 3
             size: 8MiB
     *-cpu:1
...
```


On pSeries Guest:

```
localhost
    description: pSeries Guest
    product: linux,kvm Model# 8286-42A
    vendor: IBM
    serial: 10665FT
    width: 4294967295 bits
    capabilities: smp
    configuration: uuid=e6ce4235-4db9-4dfa-a85e-01ef29b6eb70
  *-core
       description: Motherboard
       physical id: 0
       capabilities: qemu_pseries
     *-cpu:0
          description: CPU
          product: POWER7 (architected), altivec supported
          physical id: 0
          bus info: cpu@0
          version: 2.0 (pvr 004b 0200)
          capabilities: cpufreq
          configuration: threads=1
        *-cache:0
             description: L1 Cache (data)
             physical id: 0
             size: 64KiB
        *-cache:1
             description: L1 Cache (instruction)
             physical id: 1
             size: 32KiB
     *-cpu:1
...
```


On BMC based PowerNV (Like OpenPOWER systems):

```
hab01
    description: PowerNV
    vendor: IBM
    serial: unavailable
    width: 4294967295 bits
    capabilities: smp powernv opal
  *-core
       description: Motherboard
       physical id: 0
     *-cpu:0
          description: CPU
          product: POWER8 (raw), altivec supported
          physical id: 1
          bus info: cpu@0
          version: 2.0 (pvr 004d 0200)
          size: 2061MHz
          capacity: 4023MHz
          capabilities: performance-monitor cpufreq
          configuration: threads=8
        *-cache:0
             description: L1 Cache (data)
             physical id: 0
             size: 64KiB
        *-cache:1
             description: L1 Cache (instruction)
             physical id: 1
             size: 32KiB
        *-cache:2
             description: L2 Cache (unified)
             product: l2-cache
             physical id: 2
             size: 512KiB
        *-cache:3
             description: L3 Cache (unified)
             product: l3-cache
             physical id: 3
             size: 8MiB
     *-cpu:1
...
```


On pSeries LPARs:

```
ltcbrazos2-lp16.aus.stglabs.ibm.com
    description: pSeries LPAR
    product: IBM,9119-MME
    serial: IBM,02107FCD7
    width: 4294967295 bits
    capabilities: smp
  *-core
       description: Motherboard
       physical id: 0
       clock: 1600MHz
     *-cpu
          description: CPU
          product: POWER7 (architected), altivec supported
          physical id: 0
          bus info: cpu@0
          version: 2.0 (pvr 004d 0200)
          clock: 1600MHz
          capabilities: performance-monitor cpufreq
          configuration: threads=4
        *-cache:0
             description: L1 Cache (data)
             physical id: 0
             size: 64KiB
        *-cache:1
             description: L1 Cache (instruction)
             physical id: 1
             size: 32KiB
        *-cache:2
             description: L2 Cache (unified)
             product: l2-cache
             physical id: 2
             size: 512KiB
        *-cache:3
             description: L3 Cache (unified)
             product: l3-cache
             physical id: 3
             size: 8MiB
     *-firmware
          product: IBM,FW840.00 (TC840_032)
          physical id: 1
          logical name: /proc/device-tree
     *-memory
...
```
