### PR TITLE
Fix system width

### DIFF
--- a/src/core/abi.cc
+++ b/src/core/abi.cc
@@ -20,7 +20,7 @@ __ID("@(#) $Id: mem.cc 1352 2006-05-27 23:54:13Z ezix $");
 bool scan_abi(hwNode & system)
 {
   // are we compiled as 32- or 64-bit process ?
-  system.setWidth(sysconf(LONG_BIT));
+  system.setWidth(sysconf(_SC_LONG_BIT));
 
   pushd(PROC_SYS);
 


### PR DESCRIPTION
Please have a look at this patch. The corresponding ezix Moderated Submission # is 517.

Use the definition of _SC_LONG_BIT instead of LONG_BIT in abi module
while making sysconf call

When LSHW master is run on a machine, say my x86 laptop, it currently displays incorrect width information:

```
chandni
    description: Notebook
    product: 4180F59
    vendor: LENOVO
    version: ThinkPad T420
    serial: R8ACM2X
    width: 4294967295 bits
    capabilities: smbios-2.6 dmi-2.6 smp vsyscall32
    configuration: administrator_password=disabled chassis=notebook family=ThinkPad T420 power-on_password=enabled uuid=8159A50D-1E51-CB11-AC9F-CDFF49693303
  *-core
...
```


After this patch, it will start showing correct system width:

```
chandni
    description: Notebook
    product: 4180F59
    vendor: LENOVO
    version: ThinkPad T420
    serial: R8ACM2X
    width: 64 bits
    capabilities: smbios-2.6 dmi-2.6 smp vsyscall32
    configuration: administrator_password=disabled chassis=notebook family=ThinkPad T420 power-on_password=enabled uuid=8159A50D-1E51-CB11-AC9F-CDFF49693303
  *-core
...
```


Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>

Reviewed-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>