### PR TITLE
Avoid crash in scan_dmi_sysfs() when running as non-root

### DIFF
--- a/src/core/dmi.cc
+++ b/src/core/dmi.cc
@@ -1823,7 +1823,7 @@ static bool smbios_entry_point(const u8 *buf, size_t len,
 
 static bool scan_dmi_sysfs(hwNode & n)
 {
-  if (!exists(SYSFSDMI "/smbios_entry_point") || !exists(SYSFSDMI "/DMI"))
+  if (access(SYSFSDMI "/smbios_entry_point", R_OK) || access(SYSFSDMI "/DMI", R_OK))
     return false;
 
   uint32_t table_len = 0;


### PR DESCRIPTION
Instead of just checking that the sysfs files exist, make sure we
can also read them.