### PR TITLE
Use sysfs (if available) to determine hwaddr

### DIFF
--- a/src/core/network.cc
+++ b/src/core/network.cc
@@ -35,6 +35,8 @@
 #include <string.h>
 #include <string>
 #include <sys/types.h>
+#include <fstream>
+
 using namespace std;
 
 __ID("@(#) $Id$");
@@ -380,7 +382,16 @@ bool scan_network(hwNode & n)
 // get MAC address
       if (ioctl(fd, SIOCGIFHWADDR, &ifr) == 0)
       {
-        string hwaddr = getmac((unsigned char *) ifr.ifr_hwaddr.sa_data, ifr.ifr_hwaddr.sa_family);
+        string hwaddr;
+        // First try via sysfs
+        string path = "/sys/class/net/" + interface.getLogicalName() + "/address";
+        ifstream f(path.c_str());
+        if (f.good()) {   // Need to check if we have sysfs capabilities here
+          f >> hwaddr;
+        } else {
+          hwaddr = getmac((unsigned char *) ifr.ifr_hwaddr.sa_data, ifr.ifr_hwaddr.sa_family);
+        }
+        interface.setSerial(hwaddr);
         interface.addCapability(hwname(ifr.ifr_hwaddr.sa_family));
         if (ifr.ifr_hwaddr.sa_family >= 256)
           interface.addCapability("logical", _("Logical interface"));
@@ -388,8 +399,6 @@ bool scan_network(hwNode & n)
           interface.addCapability("physical", _("Physical interface"));
         interface.setDescription(string(hwname(ifr.ifr_hwaddr.sa_family)) +
           " interface");
-        interface.setSerial(hwaddr);
-
         if (isVirtual(interface.getSerial()))
           interface.addCapability("logical", _("Logical interface"));
       }


### PR DESCRIPTION
As discussed in issue #718 . This is a bit dirty. Maybe I can also add a function to read entries to the sysfs::entry class to read items directly from there? That would make it somewhat cleaner. Let me know what you think.

