### PR TITLE
Makefile: allow to pass additional LIBS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ ifneq ($(shell $(LD) --help 2| grep -- --as-needed), )
 	LDFLAGS+= -Wl,--as-needed
 endif
 LDSTATIC=-static
-LIBS=-llshw -lresolv
+LIBS+=-llshw -lresolv
 ifeq ($(SQLITE), 1)
 	LIBS+= $(shell pkg-config --libs sqlite3)
 endif

--- a/src/gui/Makefile
+++ b/src/gui/Makefile
@@ -11,7 +11,7 @@ INCLUDES=-I../core $(GTKINCLUDES)
 CXXFLAGS=-g -Wall $(INCLUDES) $(DEFINES) $(RPM_OPT_FLAGS)
 CFLAGS=$(CXXFLAGS) $(DEFINES)
 GTKLIBS=$(shell pkg-config gtk+-2.0 gmodule-2.0 --libs)
-LIBS=-L../core -llshw -lresolv $(GTKLIBS)
+LIBS+=-L../core -llshw -lresolv $(GTKLIBS)
 LDFLAGS=
 ifneq ($(shell $(LD) --help 2| grep -- --as-needed), )
 	LDFLAGS+= -Wl,--as-needed


### PR DESCRIPTION
We need to be able to pass extra LIBS when our toolchain lacks NLS
support, this way we can build libintl and link to it.  A good example
is uClibc with locale support disabled.

Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>
Signed-off-by: Romain Naour <romain.naour@gmail.com>