### PR TITLE
Adding -json option in -help output

### DIFF
--- a/src/lshw.cc
+++ b/src/lshw.cc
@@ -28,6 +28,7 @@ void usage(const char *progname)
   fprintf(stderr, _("\nformat can be\n"));
   fprintf(stderr, _("\t-html           output hardware tree as HTML\n"));
   fprintf(stderr, _("\t-xml            output hardware tree as XML\n"));
+  fprintf(stderr, _("\t-json           output hardware tree as a JSON object\n"));
   fprintf(stderr, _("\t-short          output hardware paths\n"));
   fprintf(stderr, _("\t-businfo        output bus information\n"));
   if(getenv("DISPLAY") && exists(SBINDIR"/gtk-lshw"))


### PR DESCRIPTION
Github branch corresponding to Moderated Submission #540 on ezix.org

-json works perfectly and is a recognized lshw option already.
It was only missed in printing. Nothing more needs to be done.

Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>