### PR TITLE
Expose VPD information for PCI devices with a vpd property in sysfs

### DIFF
--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -135,6 +135,59 @@ vector < string > &list)
   return true;
 }
 
+/*
+ * Read a binary blob from given @path and store it in *data.
+ * Allocates enough memory @*data, which has to be freed by the
+ * caller. If reading error occurs, *data is set to NULL and 0
+ * is returned.
+ * @return : Size of the blob read.
+ */
+int getBinaryData(const string& path, char **data)
+{
+  int size = 0, rc = 0;
+  struct stat info;
+  char *buf;
+  int fd;
+
+  if (stat(path.c_str(), &info) != 0)
+  {
+    *data = NULL;
+    goto out;
+  }
+
+  fd = open(path.c_str(), O_RDONLY);
+  if (fd < 0)
+  {
+    *data = NULL;
+    goto out;
+  }
+
+  buf = *data = new char [ info.st_size ];
+  if (!*data)
+    goto out;
+
+  while(size < info.st_size)
+  {
+    rc = read(fd, buf + size, info.st_size - size);
+    if (rc <= 0)
+      break;
+    size += rc;
+  }
+
+out:
+  if (rc < 0)
+    size = 0;
+  if (fd >= 0)
+    close(fd);
+
+  if (size == 0 && *data)
+  {
+    delete [] *data;
+    *data = NULL;
+  }
+
+  return size;
+}
 
 string get_string(const string & path,
 const string & def)

--- a/src/core/osutils.h
+++ b/src/core/osutils.h
@@ -16,6 +16,7 @@ std::string readlink(const std::string & path);
 std::string realpath(const std::string & path);
 std::string dirname(const std::string & path);
 bool loadfile(const std::string & file, std::vector < std::string > &lines);
+int getBinaryData(const std::string & path, char **data);
 
 size_t splitlines(const std::string & s,
 std::vector < std::string > &lines,

--- a/src/core/pci.cc
+++ b/src/core/pci.cc
@@ -995,6 +995,132 @@ static hwNode *scan_pci_dev(struct pci_dev &d, hwNode & n)
   return result;
 }
 
+static unsigned int parse_pci_vpd_buffer (hwNode * device,
+char *buf,
+int size)
+{
+  char key[ 3 ] = { '\0' };
+  /* Each VPD field will be at most 255 bytes long */
+  char val[ 256 ];
+  char *end = buf + size;
+  unsigned char length;
+  uint16_t len, vpd_R_data_len;
+  string field;
+
+  /*
+   * The format of the VPD Data is a series of sections, with
+   * each section containing keyword followed by length as shown
+   * below:
+   *
+   *   _ section start here
+   *  |
+   *  v
+   *  ----------------------------------------------------------
+   * | Section ID(1) | len(2) | data(len) | section1 tag(1) |   |
+   *  ----------------------------------------------------------
+   * | len (1) | key(2) | record_len(1) | data(record_len) |    |
+   *  ----------------------------------------------------------
+   * | key(2) | ....... | section2 tag(1) | len(1) | data(len)| |
+   *  ----------------------------------------------------------
+   * |.....| sectionN tag (1) | len(1) | data(len) | end tag(1) |
+   *  ----------------------------------------------------------
+   */
+
+  /* 0x82 is the value of Identifier String tag which is the first VPD
+   * tag and it provides the product name of the device.
+   * If it's not the first tag means vpd buffer is corrupt. */
+  if (*buf != 0x82)
+    return 0;
+
+  /* Increment buffer to point to offset 1 to read Product
+   * Name length
+   */
+  buf++;
+  if (buf >= end)
+    return 0;
+
+  /* Data length is 2 bytes (byte 1 LSB, byte 2 MSB) */
+  len = *buf | (buf[1] << 8);
+
+  /* Increment buffer to point to read Product Name */
+  buf += 2;
+  if (buf >= end)
+    return 0;
+
+  /* Increment buffer to point to VPD R Tag */
+  buf += len;
+  if (buf >= end)
+    return 0;
+
+  /* Increment buffer to point to VPD R Tag data length */
+  buf++;
+  if (buf >= end)
+    return 0;
+
+  vpd_R_data_len = *buf | (buf[1] << 8);
+
+  /* Increment buffer to point to first VPD keyword */
+  /* Increment by 2 because data length is of size 2 bytes */
+  buf += 2;
+  if (buf >= end)
+    return 0;
+
+  end = buf + vpd_R_data_len;
+
+  string product = "", fru = "", part = "";
+
+  /* We are only interested in the Read-Only VPD data*/
+  while( buf < end)
+  {
+    memset( key, '\0', 3 );
+    memset( val, '\0', 256 );
+
+    if( buf + 3 > end )
+      return 0;
+
+    key[ 0 ] = buf[ 0 ];
+    key[ 1 ] = buf[ 1 ];
+    length = buf[ 2 ];
+    buf += 3;
+
+    if( buf + length > end )
+      return 0;
+
+    memcpy( val, buf, length );
+    buf += length;
+    field = hw::strip(val);
+
+    string k = key;
+    if(k == "FN")
+      fru = val;
+    else
+    if(k == "PN")
+      part = val;
+    else
+    if(k == "SN")
+    {
+      /* Serial in network devices is the MAC address of the network card. Here we
+       * update serial for all but network devices since serial from network will
+       * get updated in node merge in "network.cc" module. If we update here, then
+       * "network.cc" won't be able to find the existing node to merge its node to
+       * and will end up creating two nodes for the same device */
+      string serial = val;
+      if (!serial.empty() && device->getClass() != hw::network)
+        device->setSerial(serial);
+    }
+  }
+
+  if (!part.empty())
+    product = "Part#" + part;
+  if (!fru.empty())
+    product += ((product.empty()?"":" ") + string("FRU#") + fru);
+
+  device->setProduct(
+    ((device->getProduct()).empty() ? "" : (device->getProduct() + " ")) + product);
+
+  return size;
+}
+
 bool scan_pci_legacy(hwNode & n)
 {
   FILE *f;
@@ -1176,6 +1302,20 @@ bool scan_pci(hwNode & n)
               }
               fclose(resource);
             }
+        }
+
+        string vpdpath = string(devices[i]->d_name)+"/vpd";
+        if (exists(vpdpath))
+        {
+          char *vpdData;
+          int size;
+
+          size = getBinaryData(vpdpath, &vpdData);
+          if (size > 0)
+          {
+            parse_pci_vpd_buffer(device, vpdData, size);
+            delete [] vpdData;
+          }
         }
 
         result = true;


### PR DESCRIPTION
This pull request corresponds to **Moderated Submission #541** on ezix.org

We pull the VPD information from the vpd property file in the
symlink-destination of the device symlink at /sys/bus/pci/devices/.

VPD file parsing is based on PCI specification [1].

I have provided only that VPD information which I felt was necessary and not
redundant namely: fru#, part# and serial information.

[1] http://www.xilinx.com/Attachment/PCI_SPEV_V3_0.pdf

One example of changes through a "diff -Naurp" of master branch(-) and my patch on master applied(+) on  powerio-le21.aus.stglabs.ibm.com is:

```
               *-fiber:0
                    description: Fibre Channel
-                   product: Saturn-X: LightPulse Fibre Channel Host Adapter
+                   product: Saturn-X: LightPulse Fibre Channel Host Adapter Part#00E0806
                    vendor: Emulex Corporation
                    physical id: 0
                    bus info: pci@0001:03:00.0
                    version: 03
+                   serial: 1C3360836F
                    width: 64 bits
                    clock: 33MHz
                    capabilities: pm msi msix vpd pciexpress bus_master cap_list rom

```
In another example from the same machine:

```
               *-network:0
                    description: Ethernet interface
-                   product: NetXtreme BCM5719 Gigabit Ethernet PCIe
+                   product: NetXtreme BCM5719 Gigabit Ethernet PCIe Part#00E2872 FRU#00E2873
                    vendor: Broadcom Corporation
                    physical id: 0
                    bus info: pci@0003:09:00.0

```
Yet another example from same output:

```
@@ -2175,7 +2179,7 @@ powerio-le21.aus.stglabs.ibm.com
           resources: memory:3ff200000000-3ff2007fffff ioport:2c0000000000(size=4294967296)
         *-network:0
              description: Ethernet interface
-             product: OneConnect NIC (Lancer)
+             product: OneConnect NIC (Lancer) Part#00E9267
              vendor: Emulex Corporation
              physical id: 0
              bus info: pci@0006:01:00.0

```
Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>