### PR TITLE
Display firmware information on Power System

### DIFF
--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -926,7 +926,11 @@ bool scan_device_tree(hwNode & n)
   if (matches(get_string(DEVICETREE "/compatible"), "^ibm,powernv"))
   {
     n.setVendor(get_string(DEVICETREE "/vendor", "IBM"));
-    n.setProduct(get_string(DEVICETREE "/model-name"));
+
+    if (exists(DEVICETREE "/model-name"))
+      n.setProduct(n.getProduct() + " (" +
+		   hw::strip(get_string(DEVICETREE "/model-name")) + ")");
+
     n.setDescription("PowerNV");
     if (core)
     {

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -473,6 +473,7 @@ static void scan_devtree_cpu_power(hwNode & core)
   {
     uint32_t l2_key = 0;
     uint32_t version = 0;
+    uint32_t reg;
     string basepath = string(DEVICETREE "/cpus/") + string(namelist[i]->d_name);
     hwNode cpu("cpu", hw::processor);
 
@@ -490,6 +491,9 @@ static void scan_devtree_cpu_power(hwNode & core)
 
     cpu.setDescription("CPU");
     set_cpu(cpu, currentcpu++, basepath);
+
+    reg = get_u32(basepath + "/reg");
+    cpu.setPhysId(tostring(reg));
 
     version = get_u32(basepath + "/cpu-version");
     if (version != 0)

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -927,6 +927,7 @@ bool scan_device_tree(hwNode & n)
   {
     n.setVendor(get_string(DEVICETREE "/vendor", "IBM"));
     n.setProduct(get_string(DEVICETREE "/model-name"));
+    n.setDescription("PowerNV");
     if (core)
     {
       core->addHint("icon", string("board"));
@@ -983,6 +984,7 @@ bool scan_device_tree(hwNode & n)
       scan_devtree_root(*core);
       scan_devtree_bootrom(*core);
       if (exists(DEVICETREE "/ibm,lpar-capable")) {
+        n.setDescription("pSeries LPAR");
         scan_devtree_cpu_power(*core);
         scan_devtree_memory(*core);
       }

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -931,8 +931,8 @@ bool scan_device_tree(hwNode & n)
     {
       core->addHint("icon", string("board"));
       scan_devtree_root(*core);
-      scan_devtree_memory_powernv(*core);
       scan_devtree_cpu_power(*core);
+      scan_devtree_memory_powernv(*core);
       n.addCapability("powernv", "Non-virtualized");
       n.addCapability("opal", "OPAL firmware");
     }
@@ -982,11 +982,14 @@ bool scan_device_tree(hwNode & n)
       core->addHint("icon", string("board"));
       scan_devtree_root(*core);
       scan_devtree_bootrom(*core);
-      scan_devtree_memory(*core);
-      if (exists(DEVICETREE "/ibm,lpar-capable"))
+      if (exists(DEVICETREE "/ibm,lpar-capable")) {
         scan_devtree_cpu_power(*core);
-      else
+        scan_devtree_memory(*core);
+      }
+      else {
+        scan_devtree_memory(*core);
         scan_devtree_cpu(*core);
+     }
     }
   }
 


### PR DESCRIPTION
Baremetal Power Systems has various firmware component. "/ibm,firmware-versions" node contains firmware information. Property name reflect firmware component name and value contains version.
This information is very useful for debugging various firmware issue.  This patch adds support to display these information.
