### PR TITLE
Detect disk vendor SimpleTech. Fixes #741

### DIFF
--- a/src/core/heuristics.cc
+++ b/src/core/heuristics.cc
@@ -92,7 +92,8 @@ hwNode * guessParent(const hwNode & child, hwNode & base)
 
 static const char *disk_manufacturers[] =
 {
-  "^ST.+", "Seagate",
+  "^ST(?!I\\ ).+", "Seagate",
+  "^STI\\ .+", "SimpleTech",
   "^D...-.+", "IBM",
   "^IBM.+", "IBM",
   "^HITACHI.+", "Hitachi",

--- a/src/core/ideraid.cc
+++ b/src/core/ideraid.cc
@@ -454,7 +454,8 @@ static bool probe_port(unsigned controller, unsigned disknum, hwNode & parent)
 
 static const char *manufacturers[] =
 {
-  "^ST.+", "Seagate",
+  "^ST(?!I\\ ).+", "Seagate",
+  "^STI\\ .+", "SimpleTech",
   "^D...-.+", "IBM",
   "^IBM.+", "IBM",
   "^HITACHI.+", "Hitachi",


### PR DESCRIPTION
Prevents confusing SimpleTech devices (i.e. `STI Flash X.Y.Z`) for Seagate. As discussed on [bugtracker](http://www.ezix.org/project/ticket/741).

Because recent Linux distributions have PATA devices show up as SCSI in lshw, the responsible code was actually in heuristics.cc. I have updated ideraid.cc for consistency but have no way to test it.