### PR TITLE
Fix JSON output format.

### DIFF
--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -1368,9 +1368,14 @@ string hwNode::asJSON(unsigned level)
   config = getConfigKeys();
   resources = getResources("\" value=\"");
 
+  if (level == 0)
+  {
+    out << "[" << endl;
+  }
+
   if(visible(getClassName()))
   {
-    out << "{" << endl;
+    out << spaces(2*level) << "{" << endl;
     out << spaces(2*level+2) << "\"id\" : \"" << getId() << "\"," << endl;
     out << spaces(2*level+2) << "\"class\" : \"" << getClassName() << "\"";
 
@@ -1613,26 +1618,25 @@ string hwNode::asJSON(unsigned level)
     resources.clear();
   }
 
-  
-  if(countChildren()>0)
+  for (unsigned int i = 0; i < countChildren(); i++)
   {
-    if(visible(getClassName()))
-      out << "," << endl << spaces(2*level+2) << "\"children\" : [" << endl;
-
-    for (unsigned int i = 0; i < countChildren(); i++)
+    out << getChild(i)->asJSON(visible(getClassName()) ? level + 2 : 1);
+    if (visible(getChild(i)->getClassName()))
     {
-      out << spaces(2*level+4) << getChild(i)->asJSON(visible(getClassName()) ? level + 2 : 1);
-      if(visible(getChild(i)->getClassName()) && (i < countChildren()-1)) out << "," << endl;
+      out << "," << endl;
     }
-
-    if(visible(getClassName()))
-      out << endl << spaces(2*level+2) << "]";
   }
 
   if(visible(getClassName()))
   {
     out << endl << spaces(2*level);
     out << "}";
+  }
+
+  if (level == 0)
+  {
+    out.seekp(-2, std::ios_base::end);
+    out << endl << "]" << endl;
   }
 
   return out.str();


### PR DESCRIPTION
This is already reported in http://www.ezix.org/project/ticket/456, and assigned to B.03.00 (which I assume is planned to have a cleaner solution like using jsoncpp). This however, fixes the issue as-is now (albeit using seekp). Would it be possible to roll this out, along with what's currently on master 
in a B.02.19 release, before B.03.00?

I am mainly concerned in JSON output and the fix in https://github.com/lyonel/lshw/commit/fbdc6ab15f7eea0ddcd63da355356ef156dd0d96. It would be great to have those in a release before B.03.00, since that might take some time.

Thank you.