### PR TITLE
Add AppStream appdata file

### DIFF
--- a/src/gui/integration/gtk-lshw.appdata.xml
+++ b/src/gui/integration/gtk-lshw.appdata.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Daniel Rusek <mail@asciiwolf.com> -->
+<component type="desktop">
+  <id>gtk-lshw.desktop</id>
+  <project_license>GPL-2.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>LSHW</name>
+  <summary>Provides information on hardware</summary>
+  <description>
+    <p>
+    A small tool to provide detailed information on the hardware configuration of the machine. It can report exact memory
+    configuration, firmware version, mainboard configuration, CPU version and speed, cache configuration, bus speed, etc.
+    on DMI-capable x86 systems, on some PowerPC machines (PowerMac G4 is known to work) and AMD64.
+    </p>
+  </description>
+  <url type="homepage">http://www.ezix.org/project/wiki/HardwareLiSter</url>
+  <update_contact>mail@asciiwolf.com</update_contact>
+</component>


### PR DESCRIPTION
AppStream is a cross-distro XML format to provide metadata for software components and to assign unique identifiers to software. The metadata can for example be used by software centers like GNOME Software or KDE Discover to display a user-friendly application-centric way on the package archive.

This PR adds an AppStream AppData file.