### PR TITLE
Rectify cpufreq module to map cpu frequencies to corresponding cores …

### DIFF
--- a/src/core/cpufreq.cc
+++ b/src/core/cpufreq.cc
@@ -10,6 +10,7 @@
 #include "version.h"
 #include "hw.h"
 #include "osutils.h"
+#include "cpufreq.h"
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -18,10 +19,17 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <map>
+#include <iostream>
+#include <stdexcept>
+#include <sstream>
 
 __ID("@(#) $Id$");
 
-#define DEVICESCPUFREQ "/sys/devices/system/cpu/cpu%d/cpufreq/"
+#define DEVICESCPU "/sys/devices/system/cpu/cpu%d"
+#define DEVICESCPUFREQ DEVICESCPU "/cpufreq/"
+
+using namespace std;
 
 static long get_long(const string & path)
 {
@@ -48,30 +56,177 @@ static string cpubusinfo(int cpu)
   return string(buffer);
 }
 
+static unsigned short get_ushort(const string & path)
+{
+  unsigned short result = 0;
+  FILE * in = fopen(path.c_str(), "r");
+
+  if (in)
+  {
+    if(fscanf(in, "%hu", &result) != 1)
+      result = 0;
+    fclose(in);
+  }
+
+  return result;
+}
+
+static unsigned int get_uint(const string & path)
+{
+  unsigned int result = 0;
+  FILE * in = fopen(path.c_str(), "r");
+
+  if (in)
+  {
+    if(fscanf(in, "%u", &result) != 1)
+      result = 0;
+    fclose(in);
+  }
+
+  return result;
+}
+
+unsigned long long sysfsData::get_max_freq () const
+{
+  return max_freq;
+}
+
+void sysfsData::set_max_freq (unsigned long long max_freq)
+{
+  this->max_freq = max_freq;
+}
+
+unsigned long long sysfsData::get_cur_freq () const
+{
+  return cur_freq;
+}
+
+void sysfsData::set_cur_freq (unsigned long long cur_freq)
+{
+  this->cur_freq = cur_freq;
+}
 
 bool scan_cpufreq(hwNode & node)
 {
+
   char buffer[PATH_MAX];
   unsigned i =0;
+  string desc = node.getDescription();
 
-  while(hwNode * cpu = node.findChildByBusInfo(cpubusinfo(i)))
+  if (desc=="PowerNV" || desc=="pSeries Guest" || desc=="pSeries LPAR")
   {
-    snprintf(buffer, sizeof(buffer), DEVICESCPUFREQ, i);
-    if(exists(buffer))
-    {
-      unsigned long long max, cur;
-      pushd(buffer);
+    map <uint32_t, sysfsData> core_to_data;
+    char buffer_online[PATH_MAX] = {0};
 
-                                                  // in Hz
-      max = 1000*(unsigned long long)get_long("cpuinfo_max_freq");
-                                                  // in Hz
-      cur = 1000*(unsigned long long)get_long("scaling_cur_freq");
-      cpu->addCapability("cpufreq", "CPU Frequency scaling");
-      if(cur) cpu->setSize(cur);
-      if(max>cpu->getCapacity()) cpu->setCapacity(max);
-      popd();
+    snprintf(buffer, sizeof(buffer), DEVICESCPU, i);
+
+    strncpy(buffer_online, buffer, sizeof(buffer_online) - 1);
+    buffer_online[sizeof(buffer_online) - 1] = '\0';
+
+    strncat(buffer_online, "/online",
+      sizeof(buffer_online) - strlen(buffer_online) - 1);
+
+    while(exists(buffer))
+    {
+      if (get_ushort(buffer_online) == 1)
+      {
+        //read data and add to map
+        sysfsData data;
+        unsigned long long max, cur;
+        uint32_t core_id;
+        string buffer_coreid = "";
+
+        pushd(buffer);
+
+        max = 1000*(unsigned long long)get_long("cpufreq/cpuinfo_max_freq");
+        cur = 1000*(unsigned long long)get_long("cpufreq/scaling_cur_freq");
+
+        if (max==0 && cur==0)
+        {
+          popd();
+          snprintf(buffer, sizeof(buffer), DEVICESCPU, ++i);
+          continue;
+        }
+
+        data.set_max_freq(max);
+        data.set_cur_freq(cur);
+
+        buffer_coreid = string(buffer) + string("/topology/core_id");
+        if (exists(buffer_coreid))
+        {
+          core_id = get_uint(buffer_coreid);
+          core_to_data.insert(pair<uint32_t, sysfsData>(core_id, data));
+        }
+
+        popd();
+      }
+      snprintf(buffer, sizeof(buffer), DEVICESCPU, ++i);
     }
-    i++;
+
+    i=0;
+    hwNode *cpu;
+    while((cpu = node.findChildByBusInfo(cpubusinfo(i))) &&
+          !core_to_data.empty())
+    {
+      sysfsData data;
+      string physId;
+      uint32_t reg;
+      stringstream ss;
+      try
+      {
+        unsigned long long cur, max;
+
+        physId = cpu->getPhysId();
+        ss<<physId;
+        ss>>reg;
+        data = core_to_data.at(reg);
+
+        /* We come here only when some sysfsData value corresponding to reg
+         * is found in the core_to_data map.
+	 */
+        core_to_data.erase(reg);//Erase for making next searches faster
+
+        cur = data.get_cur_freq();
+        max = data.get_max_freq();
+        cpu->addCapability("cpufreq", "CPU Frequency scaling");
+        cpu->setSize(cur);
+        if(max > cpu->getCapacity())
+          cpu->setCapacity(max);
+      }
+      catch(const out_of_range& oor)
+      {
+        /* Do nothing. Coming here indicates either:
+         * 1. kernel does not have cpufreq module loaded and hence no map entry
+         *    matching reg key is found. Catch is encountered for each cpu-core
+         *    and we skip adding cpufreq capability for all cores.
+         * 2. All SMT threads are offline for this cpu-core. We skip adding
+         *    cpufreq capability for this cpu-core.
+         */
+      }
+      i++;
+    }
+  }
+  else
+  {
+    while(hwNode * cpu = node.findChildByBusInfo(cpubusinfo(i)))
+    {
+      snprintf(buffer, sizeof(buffer), DEVICESCPUFREQ, i);
+      if(exists(buffer))
+      {
+        unsigned long long max, cur;
+        pushd(buffer);
+
+                                                    // in Hz
+        max = 1000*(unsigned long long)get_long("cpuinfo_max_freq");
+                                                    // in Hz
+        cur = 1000*(unsigned long long)get_long("scaling_cur_freq");
+        cpu->addCapability("cpufreq", "CPU Frequency scaling");
+        if(cur) cpu->setSize(cur);
+        if(max>cpu->getCapacity()) cpu->setCapacity(max);
+        popd();
+      }
+      i++;
+    }
   }
 
   return true;

--- a/src/core/cpufreq.h
+++ b/src/core/cpufreq.h
@@ -3,5 +3,18 @@
 
 #include "hw.h"
 
+class sysfsData
+{
+  unsigned long long max_freq;
+  unsigned long long cur_freq;
+
+public:
+  unsigned long long get_max_freq () const;
+  void set_max_freq (unsigned long long max_freq);
+
+  unsigned long long get_cur_freq () const;
+  void set_cur_freq (unsigned long long cur_freq);
+};
+
 bool scan_cpufreq(hwNode & n);
 #endif

--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -29,6 +29,7 @@
 #include <dirent.h>
 #include <utility>
 #include <map>
+#include <sstream>
 
 __ID("@(#) $Id$");
 
@@ -670,9 +671,10 @@ static void scan_devtree_cpu_power(hwNode & core)
   {
     uint32_t l2_key = 0;
     uint32_t version = 0;
-    uint32_t reg;
     string basepath = string(DEVICETREE "/cpus/") + string(namelist[i]->d_name);
     hwNode cpu("cpu", hw::processor);
+    stringstream ss;
+    string reg_as_string;
 
     if (!exists(basepath + "/device_type"))
     {
@@ -689,8 +691,9 @@ static void scan_devtree_cpu_power(hwNode & core)
     cpu.setDescription("CPU");
     set_cpu(cpu, currentcpu++, basepath);
 
-    reg = get_u32(basepath + "/reg");
-    cpu.setPhysId(tostring(reg));
+    ss<<get_u32(basepath + "/reg");
+    ss>>reg_as_string;
+    cpu.setPhysId(reg_as_string);
 
     version = get_u32(basepath + "/cpu-version");
     if (version != 0)


### PR DESCRIPTION
…on IBM PowerPC

The cpus under sysfs (/sys/devices/system/cpu/cpu%d) reflect all cpu threads on
the system.

We use the fact that cpu-cores under /proc/device-tree/cpus/ have a reg
property which is same as the /topology/core-id property on all its
threads that are located as some of sysfs cpus (/sys/devices/system/cpu/cpu%d)
and the fact that only the online thread has /online property in sysfs cpus as 1,
to map the (first) online sysfs cpu thread with device-tree cpu core and have the
cpu frequencies pulled from sysfs thread to the cpu.

Sample diff of lshw master output and output after this patch is applied,
on an IBM Power8 Non-Virtualized machine:

--- master.lshw	2017-09-28 08:52:15.205791183 -0500
+++ Rectify-cpufreq-module-rebase-on-master-28-Sep-2017.lshw	2017-09-28 08:53:11.726571159 -0500
@@ -13,7 +13,7 @@ ltc-tul163.aus.stglabs.ibm.com
           physical id: 40
           bus info: cpu@0
           version: 2.1 (pvr 004b 0201)
-          size: 2061MHz
+          size: 2094MHz
           capacity: 3358MHz
           capabilities: performance-monitor cpufreq
           configuration: threads=8
@@ -39,8 +39,9 @@ ltc-tul163.aus.stglabs.ibm.com
           physical id: 96
           bus info: cpu@1
           version: 2.1 (pvr 004b 0201)
-          size: 3026MHz
-          capabilities: performance-monitor
+          size: 2061MHz
+          capacity: 3358MHz
+          capabilities: performance-monitor cpufreq
           configuration: threads=8
         *-cache:0
              description: L1 Cache (instruction)
@@ -64,8 +65,9 @@ ltc-tul163.aus.stglabs.ibm.com
           physical id: 104
           bus info: cpu@2
           version: 2.1 (pvr 004b 0201)
-          size: 3026MHz
-          capabilities: performance-monitor
+          size: 3158MHz
+          capacity: 3358MHz
+          capabilities: performance-monitor cpufreq
           configuration: threads=8
         *-cache:0
              description: L1 Cache (instruction)
@@ -89,8 +91,9 @@ ltc-tul163.aus.stglabs.ibm.com
           physical id: 176
           bus info: cpu@3
           version: 2.1 (pvr 004b 0201)
-          size: 3026MHz
-          capabilities: performance-monitor
+          size: 2061MHz
+          capacity: 3358MHz
+          capabilities: performance-monitor cpufreq
           configuration: threads=8
         *-cache:0
              description: L1 Cache (instruction)
@@ -114,8 +117,9 @@ ltc-tul163.aus.stglabs.ibm.com
           physical id: 232
           bus info: cpu@4
           version: 2.1 (pvr 004b 0201)
-          size: 3026MHz
-          capabilities: performance-monitor
+          size: 2061MHz
+          capacity: 3358MHz
+          capabilities: performance-monitor cpufreq
           configuration: threads=8
         *-cache:0
              description: L1 Cache (instruction)
@@ -139,8 +143,9 @@ ltc-tul163.aus.stglabs.ibm.com
           physical id: 240
           bus info: cpu@5
           version: 2.1 (pvr 004b 0201)
-          size: 3026MHz
-          capabilities: performance-monitor
+          size: 2061MHz
+          capacity: 3358MHz
+          capabilities: performance-monitor cpufreq
           configuration: threads=8
         *-cache:0
              description: L1 Cache (instruction)
@@ -637,4 +642,3 @@ ltc-tul163.aus.stglabs.ibm.com
        size: 10Mbit/s
        capabilities: ethernet physical
        configuration: autonegotiation=off broadcast=yes driver=tun driverversion=1.6 duplex=full link=no multicast=yes port=twisted pair speed=10Mbit/s
-

Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>