### PR TITLE
Fix lshw crashes with SEGV in privileged containers

### DIFF
--- a/src/core/usb.cc
+++ b/src/core/usb.cc
@@ -373,9 +373,14 @@ bool scan_usb(hwNode & n)
   }
   filenames.clear();
 
-  usbdevices = fopen(SYSKERNELDEBUGUSBDEVICES, "r");
-  if(!usbdevices)
+  if (exists(SYSKERNELDEBUGUSBDEVICES))
+    usbdevices = fopen(SYSKERNELDEBUGUSBDEVICES, "r");
+
+  if(!usbdevices && exists(PROCBUSUSBDEVICES))
     usbdevices = fopen(PROCBUSUSBDEVICES, "r");
+
+  if(!usbdevices)
+    return false;
 
   while(!feof(usbdevices))
   {


### PR DESCRIPTION
lshw cmd segfault, when ran inside a privileged container.
All debugfs access is denied as it should be in privileged containers.

[strace of lshw]
open("/usr/share/hwdata/usb.ids", O_RDONLY) = -1 ENOENT (No such file or directory)
open("/etc/usb.ids", O_RDONLY) = -1 ENOENT (No such file or directory)
open("/usr/share/usb.ids", O_RDONLY) = -1 ENOENT (No such file or directory)
open("/usr/local/share/usb.ids", O_RDONLY) = -1 ENOENT (No such file or directory)
open("/usr/share/lshw-common/usb.ids", O_RDONLY) = -1 ENOENT (No such file or directory)
open("/usr/share/usb.ids", O_RDONLY) = -1 ENOENT (No such file or directory)
open("/sys/kernel/debug/usb/devices", O_RDONLY) = -1 EACCES (Permission denied)
open("/proc/bus/usb/devices", O_RDONLY) = -1 ENOENT (No such file or directory)
--- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=0} ---
+++ killed by SIGSEGV +++
Segmentation fault