### PR TITLE
sysfs: Fix basename() build with musl

### DIFF
--- a/src/core/sysfs.cc
+++ b/src/core/sysfs.cc
@@ -7,6 +7,7 @@
 #include "version.h"
 #include "sysfs.h"
 #include "osutils.h"
+#include <libgen.h>
 #include <limits.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -99,7 +100,7 @@ static string sysfs_getbustype(const string & path)
   {
     devname =
       string(fs.path + "/bus/") + string(namelist[i]->d_name) +
-      "/devices/" + basename(path.c_str());
+      "/devices/" + basename(const_cast<char *>(path.c_str()));
 
     if (samefile(devname, path))
       return string(namelist[i]->d_name);
@@ -139,7 +140,7 @@ static string sysfstobusinfo(const string & path)
 
   if (bustype == "usb")
   {
-    string name = basename(path.c_str());
+    string name = basename(const_cast<char *>(path.c_str()));
     if (matches(name, "^[0-9]+-[0-9]+(\\.[0-9]+)*:[0-9]+\\.[0-9]+$"))
     {
       size_t colon = name.rfind(":");
@@ -150,7 +151,7 @@ static string sysfstobusinfo(const string & path)
 
   if (bustype == "virtio")
   {
-    string name = basename(path.c_str());
+    string name = basename(const_cast<char *>(path.c_str()));
     if (name.compare(0, 6, "virtio") == 0)
       return "virtio@" + name.substr(6);
     else
@@ -158,10 +159,10 @@ static string sysfstobusinfo(const string & path)
   }
 
   if (bustype == "vio")
-    return string("vio@") + basename(path.c_str());
+    return string("vio@") + basename(const_cast<char *>(path.c_str()));
 
   if (bustype == "ccw")
-    return string("ccw@") + basename(path.c_str());
+    return string("ccw@") + basename(const_cast<char *>(path.c_str()));
 
   if (bustype == "ccwgroup")
   {
@@ -232,7 +233,7 @@ string entry::driver() const
   string driverlink = This->devpath + "/driver";
   if (!exists(driverlink))
     return "";
-  return basename(readlink(driverlink).c_str());
+  return basename(const_cast<char *>(readlink(driverlink).c_str()));
 }
 
 
@@ -320,7 +321,7 @@ string entry::name_in_class(const string & classname) const
 
 string entry::name() const
 {
-  return basename(This->devpath.c_str());
+  return basename(const_cast<char *>(This->devpath.c_str()));
 }
 
 


### PR DESCRIPTION
musl provides only standard basename() which accepts non-const string.
This fixes build error with musl C library:

    | sysfs.cc: In function 'std::__cxx11::string sysfs_getbustype(const string&)':
    | sysfs.cc:102:21: error: 'basename' was not declared in this scope
    |        "/devices/" + basename(path.c_str());
    |                      ^~~~~~~~

Signed-off-by: Krzysztof Kozlowski <krzk@kernel.org>