### PR TITLE
scsi: Fix scanning for ZBC host managed disks

### DIFF
--- a/src/core/scsi.cc
+++ b/src/core/scsi.cc
@@ -260,6 +260,10 @@ static const char *scsi_type(int type)
       return "Medium Changer";
     case 0xd:
       return "Enclosure";
+    case 0xe:
+      return "Simplified direct-access device";
+    case 0x14:
+      return "Host managed zoned block device";
     default:
       return "";
   }
@@ -706,6 +710,7 @@ static void scan_sg(hwNode & n)
   {
     case 0:
     case 14:
+    case 20:
       device = hwNode("disk", hw::disk);
       break;
     case 1:
@@ -752,7 +757,8 @@ static void scan_sg(hwNode & n)
   }
   if ((m_id.scsi_type == 4) || (m_id.scsi_type == 5))
     scan_cdrom(device);
-  if ((m_id.scsi_type == 0) || (m_id.scsi_type == 7) || (m_id.scsi_type == 14))
+  if ((m_id.scsi_type == 0) || (m_id.scsi_type == 7) ||
+      (m_id.scsi_type == 14) || (m_id.scsi_type == 20))
     scan_disk(device);
 
   if (!adapter_businfo.empty())


### PR DESCRIPTION
Properly handle scsi device type 0x14 (== 20) to add ZBC and ZAC host
managed zoned block devices to the "disk" class. While at it, also add
in scsi_type() the missing type name string for the device
type 0xe (== 14).

Signed-off-by: Damien Le Moal <damien.lemoal@wdc.com>