### PR TITLE
Space between a number and a unit of measurement

### DIFF
--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -769,6 +769,7 @@ string decimalkilos(unsigned long long value)
   }
 
   out << value;
+  out << " ";
   if ((i > 0) && (i <= strlen(prefixes)))
     out << prefixes[i - 1];
 


### PR DESCRIPTION
The International System of Units (SI) and the NIST prescribe inserting a space between a number and a unit of measurement.
* [Wikipedia - Space (punctuation) - Unit symbols and numbers](https://en.wikipedia.org/wiki/Space_(punctuation)#Unit_symbols_and_numbers)
* [Wikipedia - International System of Units - Lexicographic conventions - Unit symbols and the values of quantities - General rules](https://en.wikipedia.org/wiki/International_System_of_Units#General_rules)
* [Bureau International des Poids et Mesures - The International System of Units (SI) - Writing unit symbols and names, and expressing the values of quantities](https://www.bipm.org/utils/common/pdf/si_brochure_8_en.pdf#%5B%7B%22num%22%3A421%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22FitH%22%7D%2C845%5D)
* [NIST - Guide for the Use of the International System of Units - Rules and Style Conventions for Expressing Values of Quantities  - Space between numerical value and unit symbol](https://www.nist.gov/pml/nist-guide-si-chapter-7-rules-and-style-conventions-expressing-values-quantities#7.2)
