### PR TITLE
Add support for /dev/nvmeX NVMe controllers

### DIFF
--- a/src/core/Makefile
+++ b/src/core/Makefile
@@ -8,7 +8,7 @@ LDFLAGS=
 LDSTATIC=
 LIBS=
 
-OBJS = hw.o main.o print.o mem.o dmi.o device-tree.o cpuinfo.o osutils.o pci.o version.o cpuid.o ide.o cdrom.o pcmcia-legacy.o scsi.o s390.o disk.o spd.o network.o isapnp.o pnp.o fb.o options.o usb.o sysfs.o display.o heuristics.o parisc.o cpufreq.o partitions.o blockio.o lvm.o ideraid.o pcmcia.o volumes.o mounts.o smp.o abi.o jedec.o dump.o fat.o virtio.o vio.o
+OBJS = hw.o main.o print.o mem.o dmi.o device-tree.o cpuinfo.o osutils.o pci.o version.o cpuid.o ide.o cdrom.o pcmcia-legacy.o scsi.o nvme.o s390.o disk.o spd.o network.o isapnp.o pnp.o fb.o options.o usb.o sysfs.o display.o heuristics.o parisc.o cpufreq.o partitions.o blockio.o lvm.o ideraid.o pcmcia.o volumes.o mounts.o smp.o abi.o jedec.o dump.o fat.o virtio.o vio.o
 ifeq ($(SQLITE), 1)
 	OBJS+= db.o
 endif
@@ -23,7 +23,7 @@ lib$(PACKAGENAME).a: $(OBJS)
 	$(AR) rs $@ $^
 
 install: all
-	
+
 clean:
 	rm -f $(OBJS) lib$(PACKAGENAME).a
 
@@ -51,6 +51,7 @@ ide.o: version.h cpuinfo.h hw.h osutils.h cdrom.h disk.h heuristics.h
 cdrom.o: version.h cdrom.h hw.h partitions.h
 pcmcia-legacy.o: version.h pcmcia-legacy.h hw.h osutils.h
 scsi.o: version.h mem.h hw.h cdrom.h disk.h osutils.h heuristics.h sysfs.h
+nvme.o: version.h hw.h disk.h osutils.h sysfs.h
 disk.o: version.h disk.h hw.h osutils.h heuristics.h partitions.h
 spd.o: version.h spd.h hw.h osutils.h
 network.o: version.h config.h network.h hw.h osutils.h sysfs.h options.h

--- a/src/core/main.cc
+++ b/src/core/main.cc
@@ -29,6 +29,7 @@
 #include "pcmcia-legacy.h"
 #include "ide.h"
 #include "scsi.h"
+#include "nvme.h"
 #include "spd.h"
 #include "network.h"
 #include "isapnp.h"
@@ -132,6 +133,9 @@ bool scan_system(hwNode & system)
     status("SCSI");
     if (enabled("scsi"))
       scan_scsi(computer);
+    status("NVMe");
+    if (enabled("nvme"))
+      scan_nvme(computer);
     status("S/390 devices");
     if (enabled("s390"))
       scan_s390_devices(computer);

--- a/src/core/nvme.cc
+++ b/src/core/nvme.cc
@@ -1,0 +1,156 @@
+#include "version.h"
+#include "disk.h"
+#include "osutils.h"
+#include "sysfs.h"
+#include "hw.h"
+#include <glob.h>
+#include <libgen.h>
+
+#include <string>
+
+__ID("@(#) $Id$");
+
+#define CLASS_NVME "nvme"
+#define NVMEX "/dev/nvme[0-9]*"
+#define NVMEXNX "/dev/nvme[0-9]*n[0-9]*"
+
+static void scan_controllers(hwNode & n)
+{
+  glob_t entries;
+  size_t j;
+
+  if(glob(NVMEX, 0, NULL, &entries) == 0)
+  {
+    for(j=0; j < entries.gl_pathc; j++)
+    {
+      if(matches(entries.gl_pathv[j], "^/dev/nvme[[:digit:]]+$"))
+      {
+        string businfo = "";
+        string logicalname = "";
+        hwNode *device = NULL;
+
+        logicalname = basename(entries.gl_pathv[j]);
+        if (logicalname.empty())
+          continue;
+
+        businfo = sysfs::entry::byClass(CLASS_NVME, logicalname).businfo();
+
+        if (!businfo.empty())
+          device = n.findChildByBusInfo(businfo);
+
+        if (!device)
+          device = n.findChildByLogicalName(logicalname);
+
+        if (!device)
+        {
+          hwNode *core = n.getChild("core");
+
+          if (core)
+            device = n.getChild("nvme");
+
+          if (core && !device)
+            device = core->addChild(hwNode("nvme", hw::storage));
+        }
+
+        if (!device)
+          device = n.addChild(hwNode("nvme", hw::storage));
+
+        if (device)
+        {
+          if(device->getBusInfo().empty())
+            device->setBusInfo(businfo);
+          device->setLogicalName(logicalname);
+          device->claim();
+        }
+      }
+    }
+
+    globfree(&entries);
+  }
+}
+
+static void scan_namespaces(hwNode & n)
+{
+  glob_t entries;
+  size_t j;
+
+  if(glob(NVMEXNX, 0, NULL, &entries) == 0)
+  {
+    for(j=0; j < entries.gl_pathc; j++)
+    {
+      if(matches(entries.gl_pathv[j], "^/dev/nvme[[:digit:]]+n[[:digit:]]+$"))
+      {
+        // We get this information from sysfs rather than doing an NVMe Identify command
+        // so they may not all be available from all kernels.
+        string path = entries.gl_pathv[j];
+        string logicalname = "";
+        string parentlogicalname = "";
+        string model;
+        string serial;
+        string firmware_rev;
+        hwNode *parent = NULL;
+        hwNode device = hwNode("disk", hw::disk);
+
+        logicalname = basename(entries.gl_pathv[j]);
+        if (logicalname.empty())
+          continue;
+
+        parentlogicalname = path.substr(0, path.find_last_of("n"));
+
+        sysfs::entry e = sysfs::entry::byClass("block", logicalname);
+
+        model = e.model();
+        serial = e.serial();
+        firmware_rev = e.firmware_rev();
+
+        device.setDescription("NVMe disk");
+        device.setLogicalName(logicalname);
+        device.claim();
+
+        if (!model.empty())
+          device.setProduct(model);
+        if (!serial.empty())
+          device.setSerial(serial);
+        if (!firmware_rev.empty())
+          device.setVersion(firmware_rev);
+
+        scan_disk(device);
+
+        if (!parentlogicalname.empty())
+          parent = n.findChildByLogicalName(parentlogicalname);
+
+        if (!parent)
+        {
+          hwNode *core = n.getChild("core");
+
+          if (core)
+            parent = n.getChild("nvme");
+
+          if (core && !parent)
+            parent = core->addChild(hwNode("nvme", hw::storage));
+        }
+
+        if (!parent)
+          parent = n.addChild(hwNode("nvme", hw::storage));
+
+        if (parent)
+        {
+          parent->addChild(device);
+          parent->claim();
+        }
+      }
+    }
+
+    globfree(&entries);
+  }
+
+}
+
+bool scan_nvme(hwNode & n)
+{
+  scan_controllers(n);
+
+  scan_namespaces(n);
+
+  return false;
+}

--- a/src/core/nvme.h
+++ b/src/core/nvme.h
@@ -1,0 +1,7 @@
+#ifndef _NVME_H_
+#define _NVME_H_
+
+#include "hw.h"
+
+bool scan_nvme(hwNode & n);
+#endif

--- a/src/core/sysfs.cc
+++ b/src/core/sysfs.cc
@@ -368,6 +368,21 @@ string entry::vendor() const
   return get_string(This->devpath+"/vendor");
 }
 
+string entry::model() const
+{
+  return get_string(This->devpath+"/model");
+}
+
+string entry::serial() const
+{
+  return get_string(This->devpath+"/serial");
+}
+
+string entry::firmware_rev() const
+{
+  return get_string(This->devpath+"/firmware_rev");
+}
+
 vector < entry > sysfs::entries_by_bus(const string & busname)
 {
   vector < entry > result;

--- a/src/core/sysfs.h
+++ b/src/core/sysfs.h
@@ -28,6 +28,9 @@ namespace sysfs
       string modalias() const;
       string device() const;
       string vendor() const;
+      string model() const;
+      string serial() const;
+      string firmware_rev() const;
       entry parent() const;
       string name_in_class(const string &) const;
       string string_attr(const string & name, const string & def = "") const;


### PR DESCRIPTION
* Added nvme scanning for controllers /dev/nvme[0-9]+
* Added nvme scanning for namespaces /dev/nvme[0-9]+n[0-9]+
* Fill in namespaces as disks
* Teach partition scanning about nvme partitions /dev/nvme[0-9]+n[0-9]+p[0-9]+

I have no idea what else would need to be added for this?
* Should there be docs?
* Is this a sensible method? How about the fallbacks for parent nodes?

I think this might solve https://ezix.org/project/ticket/752

The NVMe devices I am testing with are PCI-e attached. Each NVMe device can have multiple namespaces (which appear as block devices). Does the layout I have gone for makes sense?

I have not got any more complex NVMe devices to test with, e.g. enterprise level NVMe-over-Fabrics or attached over SAS cables. That will have to come later (if anyone is interested).

All feedback / request for changes welcomed. This is marked as `WIP` until I can answer the above questions.