### PR TITLE
fix json escaping

### DIFF
--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -501,6 +501,7 @@ string escapeJSON(const string & s)
   string result = "";
 
   for (unsigned int i = 0; i < s.length(); i++)
+  {
     switch (s[i])
     {
       case '\r':
@@ -515,8 +516,21 @@ string escapeJSON(const string & s)
       case '"':
         result += "\\\"";
         break;
-    default:
-      result += s[i];
+      case '\b':
+        result += "\\b";
+        break;
+      case '\f':
+        result += "\\f";
+        break;
+      case '\\':
+        result += "\\\\";
+        break;
+      default:
+      {
+        if (32 <= s[i] && s[i] < 127)
+          result += s[i];
+      }
+    }
   }
 
   return result;


### PR DESCRIPTION
I've encountered a problem with non-valid JSON output on RAM modules with random bytes in serial number field. This patch fix such problems.