### PR TITLE
Fix abnormal termination from throwing std::bad_alloc().

### DIFF
--- a/src/core/dmi.cc
+++ b/src/core/dmi.cc
@@ -1921,6 +1921,8 @@ static bool scan_dmi_sysfs(hwNode & n)
 
   ifstream ep_stream(SYSFSDMI "/smbios_entry_point",
       ifstream::in | ifstream::binary | ifstream::ate);
+  if (!ep_stream)
+    return false;
   ifstream::pos_type ep_len = ep_stream.tellg();
   vector < u8 > ep_buf(ep_len);
   ep_stream.seekg(0, ifstream::beg);


### PR DESCRIPTION
On my system, recent updates made me start getting this exception when I
forget and run lshw as a normal user.  Investigating, I see that it is
because /sys/firmware/dmi/tables/smbios_entry_point is readable only as
root.  This means that tellg() returns -1, and the vector attempts to
allocate a LOT of memory.

I wasn't sure if the second if( !ep_stream) was still necessary (after
the call the read() ), so I left it.