### PR TITLE
x86: output the cpu family, model and stepping informations

### DIFF
--- a/src/core/cpuinfo.cc
+++ b/src/core/cpuinfo.cc
@@ -463,6 +463,12 @@ string value)
     }
     if (id == "model name")
       cpu->setProduct(value);
+    if (id == "cpu family")
+      cpu->setFamily(value);
+    if (id == "model")
+      cpu->setModel(value);
+    if (id == "stepping")
+      cpu->setStepping(value);
 //if ((id == "cpu MHz") && (cpu->getSize() == 0))
 //{
 //cpu->setSize((long long) (1000000L * atof(value.c_str())));

--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -28,7 +28,8 @@ struct hwNode_i
 {
   hwClass deviceclass;
   string id, vendor, product, version, date, serial, slot, handle, description,
-    businfo, physid, dev, modalias, subvendor, subproduct;
+    businfo, physid, dev, modalias, subvendor, subproduct, family, stepping,
+    model;
   bool enabled;
   bool claimed;
   unsigned long long start;
@@ -122,6 +123,9 @@ const string & product, const string & version)
   This->businfo = string("");
   This->physid = string("");
   This->dev = string("");
+  This->family = string("");
+  This->stepping = string("");
+  This->model = string("");
 }
 
 
@@ -427,6 +431,49 @@ void hwNode::setProduct(const string & product)
     This->product = strip(product);
 }
 
+string hwNode::getFamily() const
+{
+  if (This)
+    return This->family;
+  else
+    return "";
+}
+
+
+void hwNode::setFamily(const string & family)
+{
+  if (This)
+    This->family = strip(family);
+}
+
+string hwNode::getStepping() const
+{
+  if (This)
+    return This->stepping;
+  else
+    return "";
+}
+
+
+void hwNode::setStepping(const string & stepping)
+{
+  if (This)
+    This->stepping = strip(stepping);
+}
+
+string hwNode::getModel() const
+{
+  if (This)
+    return This->model;
+  else
+    return "";
+}
+
+void hwNode::setModel(const string & model)
+{
+  if (This)
+    This->model = strip(model);
+}
 
 string hwNode::getSubProduct() const
 {
@@ -1443,6 +1490,31 @@ string hwNode::asJSON(unsigned level)
       out << spaces(2*level+2);
       out << "\"vendor\" : \"";
       out << escapeJSON(getVendor());
+      out << "\"";
+    }
+
+    if (getFamily() != "")
+    {
+      out << "," << endl;
+      out << spaces(2*level+2);
+      out << "\"cpu family\" : \"";
+      out << escapeJSON(getFamily());
+      out << "\"";
+    }
+    if (getStepping() != "")
+    {
+      out << "," << endl;
+      out << spaces(2*level+2);
+      out << "\"stepping\" : \"";
+      out << escapeJSON(getStepping());
+      out << "\"";
+    }
+    if (getModel() != "")
+    {
+      out << "," << endl;
+      out << spaces(2*level+2);
+      out << "\"model\" : \"";
+      out << escapeJSON(getModel());
       out << "\"";
     }
 

--- a/src/core/hw.h
+++ b/src/core/hw.h
@@ -130,6 +130,15 @@ class hwNode
     string getProduct() const;
     void setProduct(const string & product);
 
+    string getFamily() const;
+    void setFamily(const string & family);
+
+    string getStepping() const;
+    void setStepping(const string & stepping);
+
+    string getModel() const;
+    void setModel(const string & model);
+
     string getSubProduct() const;
     void setSubProduct(const string & subproduct);
 

--- a/src/core/print.cc
+++ b/src/core/print.cc
@@ -221,6 +221,57 @@ int level)
       cout << endl;
     }
 
+    if (node.getFamily() != "")
+    {
+      tab(level + 1, false);
+      if (html)
+        cout << "<tr><td class=\"first\">";
+      cout << _("cpu family") << ": ";
+      if (html)
+      {
+        cout << "</td><td class=\"second\">";
+        cout << escape(node.getFamily());
+        cout << "</td></tr>";
+      }
+      else
+        cout << node.getFamily();
+      cout << endl;
+    }
+
+    if (node.getStepping() != "")
+    {
+      tab(level + 1, false);
+      if (html)
+        cout << "<tr><td class=\"first\">";
+      cout << _("stepping") << ": ";
+      if (html)
+      {
+        cout << "</td><td class=\"second\">";
+        cout << escape(node.getStepping());
+        cout << "</td></tr>";
+      }
+	else
+        cout << node.getStepping();
+      cout << endl;
+    }
+
+    if (node.getModel() != "")
+    {
+      tab(level + 1, false);
+      if (html)
+        cout << "<tr><td class=\"first\">";
+      cout << _("model") << ": ";
+      if (html)
+      {
+        cout << "</td><td class=\"second\">";
+        cout << escape(node.getModel());
+        cout << "</td></tr>";
+      }
+      else
+        cout << node.getModel();
+      cout << endl;
+    }
+
     if (node.getPhysId() != "")
     {
       tab(level + 1, false);


### PR DESCRIPTION
Currently, lshw does not output the cpu family, model and stepping
informations. Since lshw has decided to pull in things like all the
cpu flags, which are also present in '/proc/cpuinfo', then they should
also pull in the cpu family, stepping and mode.

That will help users avoid getting these informations from multiple
sources.

Signed-off-by: Lianbo Jiang <lijiang@redhat.com>