### PR TITLE
Fix type used for read to ssize_t.

### DIFF
--- a/src/core/cpuinfo.cc
+++ b/src/core/cpuinfo.cc
@@ -589,7 +589,7 @@ bool scan_cpuinfo(hwNode & n)
   if (core)
   {
     char buffer[1024];
-    size_t count;
+    ssize_t count;
     string cpuinfo_str = "";
     string description = "", version = "";
     string plat = platform();

--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -148,7 +148,7 @@ vector < string > &list)
 {
   char buffer[1024];
   string buffer_str = "";
-  size_t count = 0;
+  ssize_t count = 0;
   data_file fd = file_open(file);
 
   if (file_open_error(fd))
@@ -174,7 +174,7 @@ const string & def)
   if (fd >= 0)
   {
     char buffer[1024];
-    size_t count = 0;
+    ssize_t count = 0;
 
     memset(buffer, 0, sizeof(buffer));
     result = "";


### PR DESCRIPTION
Function declaration:
```
ssize_t read(int fd, void *buf, size_t count);
```

With size_t the following expression is always true:
```
while ((count = read(cpuinfo, buffer, sizeof(buffer))) > 0)
```

and bad things happen.