### PR TITLE
lshw command shows wrong product model

### DIFF
--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -1396,7 +1396,7 @@ static void get_ibm_model(hwNode & n)
   {
     if (ibm_model_defs[i].model == machinetype || ibm_model_defs[i].model == model)
     {
-      n.setProduct(ibm_model_defs[i].modelname);
+      n.setProduct(n.getProduct() + " (" + ibm_model_defs[i].modelname + ")");
       n.addHint("icon", string(ibm_model_defs[i].icon));
       n.setConfig("chassis", ibm_model_defs[i].chassis);
       return;


### PR DESCRIPTION
lshw | grep product | head -1
    product: Power Systems S824

Product model is displaying as "Power Systems S824" and not showing
"IBM,8286-42A". 'model' property is available on all Power system.

Append 'model' info to product instead of overwriting it.

Sample Output after the fix:

tuleta4u-lp10
    description: pSeries LPAR
    product: IBM,8286-42A (Power Systems S824)

Signed-off-by: Seeteena Thoufeek <s1seetee@linux.vnet.ibm.com>