### PR TITLE
Fix crash

### DIFF
--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -1506,7 +1506,8 @@ bool scan_device_tree(hwNode & n)
         scan_devtree_cpu_power(*core);
       }
       else {
-        scan_devtree_cpu(*core);
+        if (exists(DEVICETREE "/cpus"))
+          scan_devtree_cpu(*core);
       }
       scan_devtree_memory(*core);
       scan_devtree_memory_ibm(*core);


### PR DESCRIPTION
Fixed crash due to lack of /proc/device-tree/cpus in some environments