### PR TITLE
Add a new manufacturer to jedec.cc

### DIFF
--- a/src/core/jedec.cc
+++ b/src/core/jedec.cc
@@ -17,6 +17,7 @@ static const char * jedec_id[] = {
 	"0500",	"Elpida",
 	"07",	"Hitachi",
 	"8007",	"Hitachi",
+    "081A", "Xi'an SinoChip Semiconductor",
 	"08",	"Inmos",
 	"8008",	"Inmos",
 	"0B",	"Intersil",


### PR DESCRIPTION
We have a new manufacturer, which is not listed in  jedec_id[]  in jedec.cc. Thanks a lot