### PR TITLE
check SMBIOS version before using Type 17 Extended Size

### DIFF
--- a/src/core/dmi.cc
+++ b/src/core/dmi.cc
@@ -1567,10 +1567,13 @@ int dmiversionrev)
 
 // size
           u = data[0x0D] << 8 | data[0x0C];
-          if(u == 0x7FFF) {
-             unsigned long long extendsize = (data[0x1F] << 24) | (data[0x1E] << 16) | (data[0x1D] << 8) | data[0x1C];
-             extendsize &= 0x7FFFFFFFUL;
-             size = extendsize * 1024ULL * 1024ULL;
+          if ((dmiversionmaj > 2)
+            || ((dmiversionmaj == 2) && (dmiversionmin >= 7))) {
+             if(u == 0x7FFF) {
+                unsigned long long extendsize = (data[0x1F] << 24) | (data[0x1E] << 16) | (data[0x1D] << 8) | data[0x1C];
+                extendsize &= 0x7FFFFFFFUL;
+                size = extendsize * 1024ULL * 1024ULL;
+             }
           }
 	  else
           if (u != 0xFFFF)


### PR DESCRIPTION
If the Type 17 size field is 0x7FFF and the SMBIOS is 2.7 or newer, then the actual memory size is in the Extended Size field.  Otherwise, treat 0x7FFF as the raw and real memory size.

Microsoft Azure virtual machines have SMBIOS version 2.3 tables, and VMs with large amounts of memory (larger than 0x7FFF bytes) get reported as having many, many terabytes and even petabytes of RAM by lshw (because it interprets the ASCII strings appended to the table as the Extended Size field). In this example, a system with 64 GiB of RAM is reported as 1780 TiB:

```
# free -g
              total        used        free      shared  buff/cache   available
Mem:             62           2          59           0           1          60
Swap:             1           0           1

# lshw -short -C memory
H/W path      Device     Class          Description
===================================================
/0/0                     memory         64KiB BIOS
/0/51                    memory         1780TiB System Memory
/0/51/0                  memory         3968MiB 
/0/51/1                  memory         1780TiB 
/0/51/2                  memory         4225MiB
```

With this patch, lshw properly reports 64 GiB instead of 1780 TiB:

```
# lshw -short -C memory
H/W path          Device      Class          Description
========================================================
/0/0                          memory         64KiB BIOS
/0/51                         memory         64GiB System Memory
/0/51/0                       memory         1GiB 
/0/51/1                       memory         31GiB 
/0/51/2                       memory         31GiB 
```