### PR TITLE
Fix const correctness errors introduced in d3c66a6b2.

### DIFF
--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -1083,7 +1083,7 @@ void hwNode::setLogicalName(const string & name)
       This->logicalnames.push_back("/dev/" + n);
     }
     else
-      This->logicalnames.push_back((n[0]=='/')?n:basename(n.c_str()));
+      This->logicalnames.push_back((n[0]=='/')?n:basename(n));
 
     if(This->dev == "")
       This->dev = get_devid(n);

--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -455,6 +455,16 @@ string dirname(const string & path)
   return result;
 }
 
+string basename(const string & path)
+{
+  size_t len = path.length();
+  char *buffer = new char[len + 1];
+  path.copy(buffer, len);
+  buffer[len] = '\0';
+  string result = basename(buffer);
+  delete[] buffer;
+  return result;
+}
 
 string spaces(unsigned int count, const string & space)
 {

--- a/src/core/osutils.h
+++ b/src/core/osutils.h
@@ -15,6 +15,7 @@ bool samefile(const std::string & path1, const std::string & path2);
 std::string readlink(const std::string & path);
 std::string realpath(const std::string & path);
 std::string dirname(const std::string & path);
+std::string basename(const std::string & path);
 bool loadfile(const std::string & file, std::vector < std::string > &lines);
 
 size_t splitlines(const std::string & s,

--- a/src/core/pci.cc
+++ b/src/core/pci.cc
@@ -9,7 +9,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <libgen.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
@@ -1172,9 +1171,9 @@ bool scan_pci(hwNode & n)
           string drivername = readlink(string(devices[i]->d_name)+"/driver");
           string modulename = readlink(string(devices[i]->d_name)+"/driver/module");
 
-          device->setConfig("driver", basename(const_cast<char *>(drivername.c_str())));
+          device->setConfig("driver", basename(drivername));
           if(exists(modulename))
-            device->setConfig("module", basename(const_cast<char *>(modulename.c_str())));
+            device->setConfig("module", basename(modulename));
 
           if(exists(string(devices[i]->d_name)+"/rom"))
           {

--- a/src/core/sysfs.cc
+++ b/src/core/sysfs.cc
@@ -16,7 +16,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mount.h>
-#include <libgen.h>
 
 
 __ID("@(#) $Id$");
@@ -104,7 +103,7 @@ static string sysfs_getbustype(const string & path)
   {
     string devname =
       string(fs.path + "/bus/") + string(namelist[i]->d_name) +
-      "/devices/" + basename(const_cast<char*>(path.c_str()));
+      "/devices/" + basename(path);
 
     if (samefile(devname, path))
     {
@@ -152,7 +151,7 @@ static string sysfstobusinfo(const string & path)
 
   if (bustype == "usb")
   {
-    string name = basename(const_cast<char*>(path.c_str()));
+    string name = basename(path);
     if (matches(name, "^[0-9]+-[0-9]+(\\.[0-9]+)*:[0-9]+\\.[0-9]+$"))
     {
       size_t colon = name.rfind(":");
@@ -163,7 +162,7 @@ static string sysfstobusinfo(const string & path)
 
   if (bustype == "virtio")
   {
-    string name = basename(const_cast<char*>(path.c_str()));
+    string name = basename(path);
     if (name.compare(0, 6, "virtio") == 0)
       return "virtio@" + name.substr(6);
     else
@@ -171,10 +170,10 @@ static string sysfstobusinfo(const string & path)
   }
 
   if (bustype == "vio")
-    return string("vio@") + basename(const_cast<char*>(path.c_str()));
+    return string("vio@") + basename(path);
 
   if (bustype == "ccw")
-    return string("ccw@") + basename(const_cast<char*>(path.c_str()));
+    return string("ccw@") + basename(path);
 
   if (bustype == "ccwgroup")
   {
@@ -252,7 +251,7 @@ string entry::driver() const
   string driverlink = This->devpath + "/driver";
   if (!exists(driverlink))
     return "";
-  return basename(const_cast<char*>(readlink(driverlink).c_str()));
+  return basename(readlink(driverlink));
 }
 
 
@@ -340,7 +339,7 @@ string entry::name_in_class(const string & classname) const
 
 string entry::name() const
 {
-  return basename(const_cast<char*>(This->devpath.c_str()));
+  return basename(This->devpath);
 }
 
 
@@ -352,17 +351,17 @@ entry entry::parent() const
 
 string entry::classname() const
 {
-  return basename(const_cast<char*>(dirname(This->devpath).c_str()));
+  return basename(dirname(This->devpath));
 }
 
 string entry::subsystem() const
 {
-  return basename(const_cast<char*>(realpath(This->devpath+"/subsystem").c_str()));
+  return basename(realpath(This->devpath+"/subsystem"));
 }
 
 bool entry::isvirtual() const
 {
-  return string(basename(const_cast<char*>(dirname(dirname(This->devpath)).c_str()))) == "virtual";
+  return string(basename(dirname(dirname(This->devpath)))) == "virtual";
 }
 
 string entry::string_attr(const string & name, const string & def) const


### PR DESCRIPTION
The dirname and basename functions from libgen.h may (or not) change the
string passed to them, which is why their parameter is "char *", not
"const char *". Using "const_cast<char *>" so the compiler didn't
complain was the wrong change to make, since the underlying data of
those strings would be changed anyway.

This commit fixes that by adding a basename() wrapper in osutils.cc,
based on the existing dirname() wrapper, and using it where applicable.