### PR TITLE
Fix crashes with SEGV in scan_device

### DIFF
--- a/src/core/parisc.cc
+++ b/src/core/parisc.cc
@@ -520,6 +520,9 @@ static hwNode get_device(long hw_type, long sversion, long hversion)
 
 static bool scan_device(hwNode & node, string name = "")
 {
+  if(!exists(name))
+    return false;
+
   struct dirent **namelist;
   int n;
   hwNode * curnode = NULL;


### PR DESCRIPTION
It should return false when the path does not exist, instead of continuing.