### PR TITLE
Fix getting size of memory banks <32GiB

### DIFF
--- a/src/core/dmi.cc
+++ b/src/core/dmi.cc
@@ -1567,15 +1567,14 @@ int dmiversionrev)
 
 // size
           u = data[0x0D] << 8 | data[0x0C];
-          if ((dmiversionmaj > 2)
-            || ((dmiversionmaj == 2) && (dmiversionmin >= 7))) {
-             if(u == 0x7FFF) {
-                unsigned long long extendsize = (data[0x1F] << 24) | (data[0x1E] << 16) | (data[0x1D] << 8) | data[0x1C];
-                extendsize &= 0x7FFFFFFFUL;
-                size = extendsize * 1024ULL * 1024ULL;
-             }
+          if (((dmiversionmaj > 2)
+            || ((dmiversionmaj == 2) && (dmiversionmin >= 7)))
+            && u == 0x7FFF) {
+              unsigned long long extendsize = (data[0x1F] << 24) | (data[0x1E] << 16) | (data[0x1D] << 8) | data[0x1C];
+              extendsize &= 0x7FFFFFFFUL;
+              size = extendsize * 1024ULL * 1024ULL;
           }
-	  else
+          else
           if (u != 0xFFFF)
             size = (1024ULL * (u & 0x7FFF) * ((u & 0x8000) ? 1 : 1024ULL));
           description += string(dmi_memory_device_form_factor(data[0x0E]));


### PR DESCRIPTION
Due to a regression introduced by
8ff1efbc080c804f65f2557f9de3a5057982173d, no size was recorded for
memory banks <32GiB in size on systems with an SMBIOS version of 2.7 or
later. On these systems the Type 17 size field from SMBIOS was only
recorded if the extended size field was used.

Modify the code to use the regular size field whenever it is valid (not
0xFFFF) and not set to 0x7FFF on versions >2.7 (indicating the extended
size field is in use).

Example output after #60:

```
H/W path                 Device          Class          Description
===================================================================
/0/3                                     memory         16GiB System Memory
/0/3/0                                   memory         Row of chips LPDDR3 Sync
/0/3/1                                   memory         Row of chips LPDDR3 Sync
/0/7                                     memory         256KiB L1 cache
/0/8                                     memory         1MiB L2 cache
/0/9                                     memory         8MiB L3 cache
/0/b                                     memory         128KiB BIOS
/0/100/1f.2                              memory         Memory controller
```

After this fix:

```
H/W path                 Device          Class          Description
===================================================================
/0/3                                     memory         16GiB System Memory
/0/3/0                                   memory         8GiB Row of chips LPDDR3
/0/3/1                                   memory         8GiB Row of chips LPDDR3
/0/7                                     memory         256KiB L1 cache
/0/8                                     memory         1MiB L2 cache
/0/9                                     memory         8MiB L3 cache
/0/b                                     memory         128KiB BIOS
/0/100/1f.2                              memory         Memory controller
```