### PR TITLE
solve: Compile error when gcc version is less than 5

### DIFF
--- a/src/core/cpuinfo.cc
+++ b/src/core/cpuinfo.cc
@@ -465,13 +465,13 @@ string value)
     if (id == "model name")
       cpu->setProduct(value);
     if (id == "microcode")
-      cpu->setConfig(id, stoll(value, NULL, 0));
+      cpu->setConfig(id, strtoll(value.c_str(), NULL, 0));
     if (id == "cpu family")
-      cpu->addHint(id, stoll(value, NULL, 0));
+      cpu->addHint(id, strtoll(value.c_str(), NULL, 0));
     if (id == "model")
-      cpu->addHint(id, stoll(value, NULL, 0));
+      cpu->addHint(id, strtoll(value.c_str(), NULL, 0));
     if (id == "stepping")
-      cpu->addHint(id, stoll(value, NULL, 0));
+      cpu->addHint(id, strtoll(value.c_str(), NULL, 0));
 
     family = cpu->getHint("cpu family");
     model = cpu->getHint("model");

--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -2459,7 +2459,7 @@ long long value::asInteger() const
   switch(This->type)
   {
     case hw::text:
-      return stoll(This->s, NULL, 0);
+      return strtoll(This->s.c_str(), NULL, 0);
     case hw::integer:
       return This->ll;
     case hw::boolean:

--- a/src/core/spd.cc
+++ b/src/core/spd.cc
@@ -195,9 +195,9 @@ static bool scan_eeproms(hwNode & memory)
   {
     if (scan_eeprom(memory, namelist[i]->d_name))
       current_bank++;
-    free(namelist[i]);
+    delete(namelist[i]);
   }
-  free(namelist);
+  delete(namelist);
 
   return true;
 }


### PR DESCRIPTION
Compile error when gcc version is less than 5


log: 
`[root@localhost lshw]# make
make -C src all
make[1]: 进入目录“/root/lshw/src”
make -C core all
make[2]: 进入目录“/root/lshw/src/core”
g++ -g -Wall -g -I./core/ -DPREFIX=\"/usr\" -DSBINDIR=\"/usr/sbin\" -DMANDIR=\"/usr/share/man\" -DDATADIR=\"/usr/share\" -DVERSION=\"B.02.19.60\"  -c hw.cc -o hw.o
hw.cc: 在成员函数‘long long int hw::value::asInteger() const’中:
hw.cc:2462:38: 错误：不能将‘long long int strtoll(const char*, char**, int)’的实参‘1’从‘std::string {aka std::basic_string<char>}’转换到‘const char*’
       return strtoll(This->s, NULL, 0);
                                      ^
make[2]: *** [hw.o] 错误 1
make[2]: 离开目录“/root/lshw/src/core”
make[1]: *** [core] 错误 2
make[1]: 离开目录“/root/lshw/src”
make: *** [all] 错误 2
`



