### PR TITLE
Add support for 2.5G and 5G ethernet speeds and capabilities

### DIFF
--- a/src/core/network.cc
+++ b/src/core/network.cc
@@ -308,6 +308,106 @@ static bool isVirtual(const string & MAC)
 }
 
 
+static void updateCapabilities(hwNode & interface, u32 supported, u16 speed, u8 duplex, u8 port, u8 autoneg)
+{
+  if(supported & SUPPORTED_TP)
+    interface.addCapability("tp", _("twisted pair"));
+  if(supported & SUPPORTED_AUI)
+    interface.addCapability("aui", _("AUI"));
+  if(supported & SUPPORTED_BNC)
+    interface.addCapability("bnc", _("BNC"));
+  if(supported & SUPPORTED_MII)
+    interface.addCapability("mii", _("Media Independant Interface"));
+  if(supported & SUPPORTED_FIBRE)
+    interface.addCapability("fibre",_( "optical fibre"));
+  if(supported & SUPPORTED_10baseT_Half)
+  {
+    interface.addCapability("10bt", _("10Mbit/s"));
+    interface.setCapacity(10000000ULL);
+  }
+  if(supported & SUPPORTED_10baseT_Full)
+  {
+    interface.addCapability("10bt-fd", _("10Mbit/s (full duplex)"));
+    interface.setCapacity(10000000ULL);
+  }
+  if(supported & SUPPORTED_100baseT_Half)
+  {
+    interface.addCapability("100bt", _("100Mbit/s"));
+    interface.setCapacity(100000000ULL);
+  }
+  if(supported & SUPPORTED_100baseT_Full)
+  {
+    interface.addCapability("100bt-fd", _("100Mbit/s (full duplex)"));
+    interface.setCapacity(100000000ULL);
+  }
+  if(supported & SUPPORTED_1000baseT_Half)
+  {
+    interface.addCapability("1000bt", "1Gbit/s");
+    interface.setCapacity(1000000000ULL);
+  }
+  if(supported & SUPPORTED_1000baseT_Full)
+  {
+    interface.addCapability("1000bt-fd", _("1Gbit/s (full duplex)"));
+    interface.setCapacity(1000000000ULL);
+  }
+  if(supported & SUPPORTED_10000baseT_Full)
+  {
+    interface.addCapability("10000bt-fd", _("10Gbit/s (full duplex)"));
+    interface.setCapacity(10000000000ULL);
+  }
+  if(supported & SUPPORTED_Autoneg)
+    interface.addCapability("autonegotiation", _("Auto-negotiation"));
+
+  switch(speed)
+  {
+    case SPEED_10:
+      interface.setConfig("speed", "10Mbit/s");
+      interface.setSize(10000000ULL);
+      break;
+    case SPEED_100:
+      interface.setConfig("speed", "100Mbit/s");
+      interface.setSize(100000000ULL);
+      break;
+    case SPEED_1000:
+      interface.setConfig("speed", "1Gbit/s");
+      interface.setSize(1000000000ULL);
+      break;
+    case SPEED_10000:
+      interface.setConfig("speed", "10Gbit/s");
+      interface.setSize(10000000000ULL);
+      break;
+  }
+  switch(duplex)
+  {
+    case DUPLEX_HALF:
+      interface.setConfig("duplex", "half");
+      break;
+    case DUPLEX_FULL:
+      interface.setConfig("duplex", "full");
+      break;
+  }
+  switch(port)
+  {
+    case PORT_TP:
+      interface.setConfig("port", "twisted pair");
+      break;
+    case PORT_AUI:
+      interface.setConfig("port", "AUI");
+      break;
+    case PORT_BNC:
+      interface.setConfig("port", "BNC");
+      break;
+    case PORT_MII:
+      interface.setConfig("port", "MII");
+      break;
+    case PORT_FIBRE:
+      interface.setConfig("port", "fibre");
+      break;
+  }
+  interface.setConfig("autonegotiation", (autoneg == AUTONEG_DISABLE) ?  "off" : "on");
+}
+
+
 bool scan_network(hwNode & n)
 {
   vector < string > interfaces;
@@ -423,101 +523,7 @@ bool scan_network(hwNode & n)
       ifr.ifr_data = (caddr_t) &ecmd;
       if (ioctl(fd, SIOCETHTOOL, &ifr) == 0)
       {
-        if(ecmd.supported & SUPPORTED_TP)
-          interface.addCapability("tp", _("twisted pair"));
-        if(ecmd.supported & SUPPORTED_AUI)
-          interface.addCapability("aui", _("AUI"));
-        if(ecmd.supported & SUPPORTED_BNC)
-          interface.addCapability("bnc", _("BNC"));
-        if(ecmd.supported & SUPPORTED_MII)
-          interface.addCapability("mii", _("Media Independant Interface"));
-        if(ecmd.supported & SUPPORTED_FIBRE)
-          interface.addCapability("fibre",_( "optical fibre"));
-        if(ecmd.supported & SUPPORTED_10baseT_Half)
-        {
-          interface.addCapability("10bt", _("10Mbit/s"));
-          interface.setCapacity(10000000ULL);
-        }
-        if(ecmd.supported & SUPPORTED_10baseT_Full)
-        {
-          interface.addCapability("10bt-fd", _("10Mbit/s (full duplex)"));
-          interface.setCapacity(10000000ULL);
-        }
-        if(ecmd.supported & SUPPORTED_100baseT_Half)
-        {
-          interface.addCapability("100bt", _("100Mbit/s"));
-          interface.setCapacity(100000000ULL);
-        }
-        if(ecmd.supported & SUPPORTED_100baseT_Full)
-        {
-          interface.addCapability("100bt-fd", _("100Mbit/s (full duplex)"));
-          interface.setCapacity(100000000ULL);
-        }
-        if(ecmd.supported & SUPPORTED_1000baseT_Half)
-        {
-          interface.addCapability("1000bt", "1Gbit/s");
-          interface.setCapacity(1000000000ULL);
-        }
-        if(ecmd.supported & SUPPORTED_1000baseT_Full)
-        {
-          interface.addCapability("1000bt-fd", _("1Gbit/s (full duplex)"));
-          interface.setCapacity(1000000000ULL);
-        }
-        if(ecmd.supported & SUPPORTED_10000baseT_Full)
-        {
-          interface.addCapability("10000bt-fd", _("10Gbit/s (full duplex)"));
-          interface.setCapacity(10000000000ULL);
-        }
-        if(ecmd.supported & SUPPORTED_Autoneg)
-          interface.addCapability("autonegotiation", _("Auto-negotiation"));
-
-        switch(ecmd.speed)
-        {
-          case SPEED_10:
-            interface.setConfig("speed", "10Mbit/s");
-            interface.setSize(10000000ULL);
-            break;
-          case SPEED_100:
-            interface.setConfig("speed", "100Mbit/s");
-            interface.setSize(100000000ULL);
-            break;
-          case SPEED_1000:
-            interface.setConfig("speed", "1Gbit/s");
-            interface.setSize(1000000000ULL);
-            break;
-          case SPEED_10000:
-            interface.setConfig("speed", "10Gbit/s");
-            interface.setSize(10000000000ULL);
-            break;
-        }
-        switch(ecmd.duplex)
-        {
-          case DUPLEX_HALF:
-            interface.setConfig("duplex", "half");
-            break;
-          case DUPLEX_FULL:
-            interface.setConfig("duplex", "full");
-            break;
-        }
-        switch(ecmd.port)
-        {
-          case PORT_TP:
-            interface.setConfig("port", "twisted pair");
-            break;
-          case PORT_AUI:
-            interface.setConfig("port", "AUI");
-            break;
-          case PORT_BNC:
-            interface.setConfig("port", "BNC");
-            break;
-          case PORT_MII:
-            interface.setConfig("port", "MII");
-            break;
-          case PORT_FIBRE:
-            interface.setConfig("port", "fibre");
-            break;
-        }
-        interface.setConfig("autonegotiation", (ecmd.autoneg == AUTONEG_DISABLE) ?  "off" : "on");
+        updateCapabilities(interface, ecmd.supported, ecmd.speed, ecmd.duplex, ecmd.port, ecmd.autoneg);
       }
 
       drvinfo.cmd = ETHTOOL_GDRVINFO;


### PR DESCRIPTION
Switch to "new" (from 2016) ETHTOOL_GLINKSETTINGS command to get extended link mode fields. Keep fallback to old implementation for older kernels.

It should be easy to add 25G/40G and so on after this.

I have tried to keep to the coding style of the file.

### Example outputs:

USB interface:
```
  *-network
       description: Ethernet interface
       physical id: 18
       bus info: usb@7:1
       logical name: enp6s0f4u1
       serial: 00:e0:4c:68:yy:zz
       size: 10Mbit/s
       capacity: 2500Mbit/s
       capabilities: ethernet physical tp mii 10bt 10bt-fd 100bt 100bt-fd 1000bt 1000bt-fd 2500bt-fd autonegotiation
       configuration: autonegotiation=on broadcast=yes driver=r8152 driverversion=v1.12.11 duplex=half firmware=rtl8156b-2 v1 04/15/21 link=no multicast=yes port=MII speed=10Mbit/s

  *-network
       description: Ethernet interface
       physical id: e
       bus info: usb@7:1
       logical name: enp6s0f4u1
       serial: 00:e0:4c:68:00:23
       size: 2500Mbit/s
       capacity: 2500Mbit/s
       capabilities: ethernet physical tp mii 10bt 10bt-fd 100bt 100bt-fd 1000bt 1000bt-fd 2500bt-fd autonegotiation
       configuration: autonegotiation=on broadcast=yes driver=r8152 driverversion=v1.12.11 duplex=full firmware=rtl8156b-2 v1 04/15/21 ip=10.4.4.121 link=yes multicast=yes port=MII speed=2.5Gbit/s
```

PCIe interface
```
  *-network
       description: Ethernet interface
       product: RTL8125 2.5GbE Controller
       vendor: Realtek Semiconductor Co., Ltd.
       physical id: 0
       bus info: pci@0000:03:00.0
       logical name: right
       version: 04
       serial: 20:0d:b0:46:yy:zz
       capacity: 2500Mbit/s
       width: 64 bits
       clock: 33MHz
       capabilities: bus_master cap_list rom ethernet physical tp mii 10bt 10bt-fd 100bt 100bt-fd 1000bt-fd 2500bt-fd autonegotiation
       configuration: autonegotiation=on broadcast=yes driver=r8169 driverversion=5.11.0-37-generic firmware=rtl8125b-2_0.0.2 07/13/20 latency=0 link=no multicast=yes port=twisted pair
       resources: irq:19 ioport:4000(size=256) memory:a3b10000-a3b1ffff memory:a3b20000-a3b23fff memory:a3b00000-a3b0ffff

  *-network
       description: Ethernet interface
       product: RTL8125 2.5GbE Controller
       vendor: Realtek Semiconductor Co., Ltd.
       physical id: 0
       bus info: pci@0000:03:00.0
       logical name: right
       version: 04
       serial: 20:0d:b0:46:yy:zz
       size: 2500Mbit/s
       capacity: 2500Mbit/s
       width: 64 bits
       clock: 33MHz
       capabilities: bus_master cap_list rom ethernet physical tp mii 10bt 10bt-fd 100bt 100bt-fd 1000bt-fd 2500bt-fd autonegotiation
       configuration: autonegotiation=on broadcast=yes driver=r8169 driverversion=5.11.0-37-generic duplex=full firmware=rtl8125b-2_0.0.2 07/13/20 latency=0 link=yes multicast=yes port=twisted pair speed=2.5Gbit/s
       resources: irq:19 ioport:4000(size=256) memory:a3b10000-a3b1ffff memory:a3b20000-a3b23fff memory:a3b00000-a3b0ffff
```