### PR TITLE
Read and parse network transceiver module eeprom

### DIFF
--- a/src/core/network.cc
+++ b/src/core/network.cc
@@ -111,6 +111,14 @@ struct ethtool_modinfo {
 #define SFF_8024_ID_SFP                         0x3
 #define SFF_8024_EXT_ID_DEFINED_BY_2WIRE_ID     0x4
 
+/* Common connector types. */
+#define SFF_8024_CONNECTOR_SC                   0x1
+#define SFF_8024_CONNECTOR_LC                   0x7
+#define SFF_8024_CONNECTOR_OPTICAL_PIGTAIL      0xb
+#define SFF_8024_CONNECTOR_COPPER_PIGTAIL       0x21
+#define SFF_8024_CONNECTOR_RJ45                 0x22
+#define SFF_8024_CONNECTOR_NON_SEPARABLE        0x23
+
 #define MAX_EEPROM_SIZE 256
 struct ethtool_eeprom {
   u32 cmd;
@@ -449,6 +457,27 @@ static void scan_module(hwNode & interface, int fd)
         {
           snprintf(buffer, sizeof(buffer), "%dm", max_length);
           interface.setConfig("maxlength", buffer);
+        }
+        switch (eeeprom.data[2])
+        {
+          case SFF_8024_CONNECTOR_SC:
+            interface.setConfig("connector", "SC");
+            break;
+          case SFF_8024_CONNECTOR_LC:
+            interface.setConfig("connector", "LC");
+            break;
+          case SFF_8024_CONNECTOR_OPTICAL_PIGTAIL:
+            interface.setConfig("connector", "optical pigtail");
+            break;
+          case SFF_8024_CONNECTOR_COPPER_PIGTAIL:
+            interface.setConfig("connector", "copper pigtail");
+            break;
+          case SFF_8024_CONNECTOR_RJ45:
+            interface.setConfig("connector", "RJ45");
+            break;
+          case SFF_8024_CONNECTOR_NON_SEPARABLE:
+            interface.setConfig("connector", "non separable");
+            break;
         }
       }
       break;

--- a/src/core/network.cc
+++ b/src/core/network.cc
@@ -422,6 +422,8 @@ static void scan_module(hwNode & interface, int fd)
           eeeprom.data[1] == SFF_8024_EXT_ID_DEFINED_BY_2WIRE_ID)
       {
         char buffer[32];
+        /* Get part number (padded with space). String is stripped inside setConfig. */
+        interface.setConfig("module", string((const char*)&eeeprom.data[40], 16));
         int wavelength = eeeprom.data[60] << 8 | eeeprom.data[61];
         /* Skip wavelength for SFP+ cables, they use byte 60 for other data. */
         if ((eeeprom.data[8] & 0x0C) == 0 && wavelength > 0)


### PR DESCRIPTION
Extract part number, supported length, wavelength and connector for network cards using SFP/SFP+/SFP28 transceiver modules (fibre, rj45 or direct attach cables)

Root permissions are required to get the data.

It would be nice if some attribution was left when merging, for example via `--author="name <email>"` as argument to `git` when commiting

### Testing

It agrees with the parsing done by `ethtool`:

New configurations: `connector=LC maxlength=20000m module=TL-SM321B wavelength=1310nm` from
```
$ sudo ethtool -m eth0
    Identifier                                : 0x03 (SFP)
    Extended identifier                       : 0x04 (GBIC/SFP defined by 2-wire interface ID)
    Connector                                 : 0x07 (LC)
    Transceiver codes                         : 0x00 0x00 0x00 0x02 0x82 0x00 0x01 0x01 0x00
    Transceiver type                          : Ethernet: 1000BASE-LX
    Transceiver type                          : FC: very long distance (V)
    Transceiver type                          : FC: Longwave laser (LC)
    Transceiver type                          : FC: Single Mode (SM)
    Transceiver type                          : FC: 100 MBytes/sec
    Encoding                                  : 0x01 (8B/10B)
    BR, Nominal                               : 1300MBd
    Rate identifier                           : 0x00 (unspecified)
    Length (SMF,km)                           : 20km
    Length (SMF)                              : 20000m
    Length (50um)                             : 0m
    Length (62.5um)                           : 0m
    Length (Copper)                           : 0m
    Length (OM3)                              : 0m
    Laser wavelength                          : 1310nm
    Vendor name                               : TP-LINK
    Vendor OUI                                : 00:00:00
    Vendor PN                                 : TL-SM321B
    Vendor rev                                : 1.1
```
New configurations: `maxlength=100m module=UF-RJ45-1G` from
```
$ sudo ethtool -m eth0
    Identifier                                : 0x03 (SFP)
    Extended identifier                       : 0x04 (GBIC/SFP defined by 2-wire interface ID)
    Connector                                 : 0x00 (unknown or unspecified)
    Transceiver codes                         : 0x00 0x00 0x00 0x08 0x00 0x00 0x00 0x00 0x00
    Transceiver type                          : Ethernet: 1000BASE-T
    Encoding                                  : 0x01 (8B/10B)
    BR, Nominal                               : 1300MBd
    Rate identifier                           : 0x00 (unspecified)
    Length (SMF,km)                           : 0km
    Length (SMF)                              : 0m
    Length (50um)                             : 0m
    Length (62.5um)                           : 0m
    Length (Copper)                           : 100m
    Length (OM3)                              : 0m
    Laser wavelength                          : 0nm
    Vendor name                               : UBNT
    Vendor OUI                                : 00:00:00
    Vendor PN                                 : UF-RJ45-1G
    Vendor rev                                : 1.0
```

New configurations: `connector=LC maxlength=10000m module=SFP-10G-BX wavelength=1270nm` from
```
$ sudo ethtool -m eth0
    Identifier                                : 0x03 (SFP)
    Extended identifier                       : 0x04 (GBIC/SFP defined by 2-wire interface ID)
    Connector                                 : 0x07 (LC)
    Transceiver codes                         : 0x20 0x00 0x00 0x00 0x20 0x00 0x01 0x00 0x00
    Transceiver type                          : 10G Ethernet: 10G Base-LR
    Transceiver type                          : FC: intermediate distance (I)
    Transceiver type                          : FC: Single Mode (SM)
    Encoding                                  : 0x06 (64B/66B)
    BR, Nominal                               : 10300MBd
    Rate identifier                           : 0x00 (unspecified)
    Length (SMF,km)                           : 10km
    Length (SMF)                              : 10000m
    Length (50um)                             : 0m
    Length (62.5um)                           : 0m
    Length (Copper)                           : 0m
    Length (OM3)                              : 0m
    Laser wavelength                          : 1270nm
    Vendor name                               : FS
    Vendor OUI                                : 00:00:00
    Vendor PN                                 : SFP-10G-BX
    Vendor rev                                :
```

New configurations: `connector=LC maxlength=300m module=FTLX8571D3BCL wavelength=850nm` from
```
$ sudo ethtool -m top
	Identifier                                : 0x03 (SFP)
	Extended identifier                       : 0x04 (GBIC/SFP defined by 2-wire interface ID)
	Connector                                 : 0x07 (LC)
	Transceiver codes                         : 0x10 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
	Transceiver type                          : 10G Ethernet: 10G Base-SR
	Encoding                                  : 0x06 (64B/66B)
	BR, Nominal                               : 10300MBd
	Rate identifier                           : 0x00 (unspecified)
	Length (SMF,km)                           : 0km
	Length (SMF)                              : 0m
	Length (50um)                             : 80m
	Length (62.5um)                           : 30m
	Length (Copper)                           : 0m
	Length (OM3)                              : 300m
	Laser wavelength                          : 850nm
	Vendor name                               : FINISAR CORP.
	Vendor OUI                                : 00:90:65
	Vendor PN                                 : FTLX8571D3BCL
	Vendor rev                                : A
```