### PR TITLE
fixup cannot find memory type bug in alpha architecture, do not ignore multiple nodes.

### DIFF
--- a/src/core/dmi.cc
+++ b/src/core/dmi.cc
@@ -1465,14 +1465,16 @@ int dmiversionrev)
               description = _("Cache Memory");
               memory_icon = true;
               break;
+            case 0x08:
+              description = _("System memory");
+              memory_icon = true;
+              break;
             default:
               description = _("Generic Memory");
               memory_icon = true;
           }
           if (id == "memory" && hardwarenode->getChild("memory"))
           {
-            // we don't want multiple "System memory" nodes,
-            // so just ignore this one
             break;
           }
           hwNode newnode(id, hw::memory);

--- a/src/core/dmi.cc
+++ b/src/core/dmi.cc
@@ -1589,7 +1589,7 @@ int dmiversionrev)
             char buffer[80];
             u = data[0x16] << 8 | data[0x15];
 // speed
-            clock = u * 1000000;                  // u is a frequency in MHz
+            clock = u * 1000000ULL;                  // u is a frequency in MHz
             if (u == 0)
               strcpy(buffer, "");
             else


### PR DESCRIPTION
wen found in alpha architecture need multiple "System memory" nodes,so we add case 0x08 do not ignore System memory nodes.