### PR TITLE
Problem with modifying open file descriptors but not closing them

### DIFF
--- a/src/core/fb.cc
+++ b/src/core/fb.cc
@@ -333,9 +333,9 @@ bool scan_fb(hwNode & n)
       break;
   }
 
-  for (unsigned int j = 0; j < fbdevs; j++)
+  for (unsigned int j = 0; j < MAX_FB; j++)
   {
-    close(fd[j]);
+    if(fd[j] >= 3) close(fd[j]);
   }
 
   return false;


### PR DESCRIPTION
On the debian10 system, run the ./src/lshw program. This program opens /dev/fb-pid, but does not close the file descriptor.

ex:
lr-x------ 1 root root 64 1月  28 13:39 3 -> '/dev/fb-28506 (deleted)'

![image](https://user-images.githubusercontent.com/22900394/151494570-e245de08-3ab3-4866-b528-c4f4ca6b35a1.png)
This line of code does not close any files.