### PR TITLE
src/core/osutils.cc: Fix std::length_error exception on reading the s…

### DIFF
--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -181,8 +181,16 @@ const string & def)
     result = "";
 
     while ((count = read(fd, buffer, sizeof(buffer))) > 0)
+    {
+      /* Validate the string length before processing.*/
+      if (count > result.max_size())
+      {
+          fprintf(stderr, "Can`t read the string with size %lu\n", count);
+          result = def;
+          return result;
+      }
       result += string(buffer, count);
-
+    }
     close(fd);
   }
 


### PR DESCRIPTION
…tring attributes in sysfs.

Add checking for std:string buffer overflow on reading string attribute from sysfs
to fix the issue [1] that was reproduced on reading mmc device info on
LS-ok1046ac2v1 Hardware  based on [2] chip.

Reference:
1. terminate called after throwing an instance of 'std::length_error'
2. https://www.nxp.com/products/processors-and-microcontrollers/arm-processors/layerscape-processors/layerscape-1046a-and-1026a-processors:LS1046A

Signed-off-by: Sergiy Neodnichyk <SergiyN@sapling-inc.com>