### PR TITLE
Print children in json, even if output:list is enabled

### DIFF
--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -1650,40 +1650,34 @@ string hwNode::asJSON(unsigned level)
     resources.clear();
   }
 
-  if(!::enabled("output:list") && countChildren()>0)
+  if(countChildren()>0)
   {
-    out << "," << endl;
-    out << spaces(2*level+2);
-    out << "\"children\" : [";
+    bool needcomma = false;
+    if(visible(getClassName())){
+      out << "," << endl;
+      out << spaces(2*level+2);
+      out << "\"children\" : [";
+    }
     for (unsigned int i = 0; i < countChildren(); i++)
     {
-      out << getChild(i)->asJSON(visible(getClassName()) ? level + 2 : 1);
-      if (visible(getChild(i)->getClassName()) && i<countChildren()-1)
+      string json = getChild(i)->asJSON(visible(getClassName()) ? level + 2 : 1);
+
+      if(needcomma && strip(json)!="")
       {
         out << "," << endl;
       }
+      out << json;
+      needcomma |= strip(json)!="";
     }
-    out << "]";
+    if(visible(getClassName())){
+      out << "]";
+    }
   }
 
   if(visible(getClassName()))
   {
     out << endl << spaces(2*level);
     out << "}";
-  }
-
-  if(::enabled("output:list") && countChildren()>0)
-  {
-    bool needcomma = visible(getClassName());
-    for (unsigned int i = 0; i < countChildren(); i++)
-      {
-        string json = getChild(i)->asJSON(visible(getClassName()) ? level + 2 : 1);
-
-        if(needcomma && strip(json)!="")
-          out << "," << endl;
-        out << getChild(i)->asJSON(visible(getClassName()) ? level + 2 : 1);
-        needcomma |= strip(json)!="";
-      }
   }
 
   if (::enabled("output:list") && level == 0)


### PR DESCRIPTION
When output:list is enabled, the json output shows the children structure before commit 15565229509455527de9ce7cbb9530e2b31d043b, but this behavior was changed after the commit.

I don't know if this is intended, but I think  that children structure is pretty useful, especially for NVMe disks.
It is pretty hard to track which namespace belongs to which disk without showing the structure.

If not printing children is intended behavior, I would suggest give an extra option to change output:list to false even when pass `-c <class>` argument. 