### PR TITLE
parisc: Fix reading random directories if pushd fails

### DIFF
--- a/src/core/parisc.cc
+++ b/src/core/parisc.cc
@@ -593,7 +593,9 @@ bool scan_parisc(hwNode & node)
 
   if(core->getDescription()=="")
     core->setDescription("Motherboard");
-  pushd(DEVICESPARISC);
+
+  if(!pushd(DEVICESPARISC))
+    return false;
   scan_device(*core);
   popd();
 


### PR DESCRIPTION
When `/sys/devices/parisc` does not exist, any directory with a name consisting of only numbers in current working directory was being interpreted as a device, for example:

```
krzys_h@krzysh-laptop:/mnt/ramdisk $ ls /sys/devices/parisc
ls: cannot access '/sys/devices/parisc': No such file or directory
krzys_h@krzysh-laptop:/mnt/ramdisk $ mkdir 13374242
krzys_h@krzysh-laptop:/mnt/ramdisk $ sudo lshw | grep 13374242 -B3 -A3
             width: 64 bits 
             clock: 1600MHz (0.6ns)
     *-generic UNCLAIMED
          physical id: 13374242
          bus info: parisc@13374242
     *-pci
          description: Host bridge
          product: Xeon E3-1200 v3/4th Gen Core Processor DRAM Controller
```

This commit fixes that by properly checking the return value from pushd.

PS. I was unable to submit it as an issue to the bug tracker because of problems with the captcha (the same ones mentioned at #82, probably), so I just fixed it myself and posted it as a PR instead... the upstream Gitea has registration disabled too, so I had to post it here