### PR TITLE
Output the serial string of virtio disks

### DIFF
--- a/src/core/virtio.cc
+++ b/src/core/virtio.cc
@@ -26,6 +26,10 @@ static void scan_virtio_block(hwNode & device, const sysfs::entry & entry)
   if (devname.empty())
     return;
   device.setLogicalName(devname);
+  vector<sysfs::entry> e = entry.devices();
+  if (e.size() == 1) {
+    device.setSerial(e[0].string_attr("serial"));
+  }
   scan_disk(device);
   device.claim();
 }


### PR DESCRIPTION
Previously, the serial string of virtio disks is not outputted. For example we can observe the issue if we have the following virtio disk configuration:
```
  <target dev="vda" bus="virtio"/>
  <serial>vblk1</serial>

Before:
       description: Virtual I/O device
       physical id: 0
       bus info: virtio@3
       logical name: /dev/vda
       size: 8GiB (8589MB)
       capabilities: partitioned partitioned:dos

After:
       description: Virtual I/O device
       physical id: 0
       bus info: virtio@3
       logical name: /dev/vda
       serial: vblk1
       size: 8GiB (8589MB)
       capabilities: partitioned partitioned:dos
```
Signed-off-by: Tao Liu <ltao@redhat.com>