### PR TITLE
Fix 'std::length_error' exception

### DIFF
--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -181,7 +181,12 @@ const string & def)
     result = "";
 
     while ((count = read(fd, buffer, sizeof(buffer))) > 0)
-      result += string(buffer, count);
+      if ((result.size() + count) < result.max_size())
+        result += string(buffer, count);
+      else {
+        fprintf(stderr, "WARNING: string in [%s] is too big, truncating it.\n", path.c_str());
+        break;
+      }
 
     close(fd);
   }


### PR DESCRIPTION
When the content of a path is too big, get_string() might overflow the string object and the execution is aborted with the following error:

terminate called after throwing an instance of 'std::length_error'
  what():  basic_string::_M_create
Aborted

Fix that by checking the maximum size of the string object before appending to it.

Signed-off-by: Sergio Prado <sergio.prado@toradex.com>