### PR TITLE
NVMe: Fix issue with multipath parameter value comparision

### DIFF
--- a/src/core/nvme.cc
+++ b/src/core/nvme.cc
@@ -52,7 +52,7 @@ bool scan_nvme(hwNode & n)
       ns.setDescription("NVMe disk");
       // try to guess correct logical name when native NVMe multipath is enabled for NVMe devices
       if(!exists("/dev/"+n.name()) &&
-		      uppercase(get_string("/sys/module/nvme_core/parameters/multipath"))=="Y" &&
+		      uppercase(hw::strip(get_string("/sys/module/nvme_core/parameters/multipath")))=="Y" &&
 		      matches(n.name(), "^nvme[0-9]+c[0-9]+n[0-9]+$")) {
 	      size_t indexc = n.name().find("c");
 	      size_t indexn = n.name().find("n", indexc);


### PR DESCRIPTION
Fixes: e7cde93 ("NVMe: fix logical name with native multipath")

Currently, code is using the get_string() to read the contents of the `/sys/module/nvme_core/parameters/multipath` file and comparing it to the string "Y". However, the get_string function is returning "Y\n" which is not the same as "Y", causing the comparison to fail.

To fix this, use the `hw::strip` function to remove the newline character, before the comparison. This ensures that the comparison is made correctly.

Before this fix:
```
$ ./src/lshw -c disk | grep "logical name"
       logical name: nvme1c1n1
       logical name: nvme2c2n1
       logical name: nvme3c3n1
       logical name: /dev/sda
       logical name: /dev/sdb
```

After this fix:
```
$ ./src/lshw -c disk | grep "logical name"
       logical name: /dev/nvme1n1
       logical name: /dev/nvme2n1
       logical name: /dev/nvme3n1
       logical name: /dev/sda
       logical name: /dev/sdb
```
Signed-off-by: Sathvika Vasireddy <sv@linux.ibm.com>