### PR TITLE
fix: scan_devtree_cpu noncache free cachelist

### DIFF
--- a/src/core/device-tree.cc
+++ b/src/core/device-tree.cc
@@ -413,7 +413,12 @@ static void scan_devtree_cpu(hwNode & core)
 
           if (hw::strip(get_string(cachebase + "/device_type")) != "cache" &&
             hw::strip(get_string(cachebase + "/device_type")) != "l2-cache")
-            break;                                // oops, not a cache!
+            {
+              // free caches nodes
+              for (int k = j; k < ncache; k++)
+                free(cachelist[k]);
+              break; // oops, not a cache!
+            }
 
 	  cache.setClock(get_u32(cachebase + "/clock-frequency"));
 	  fill_cache_info("L2 Cache", cachebase, cache, icache);


### PR DESCRIPTION
porting lshw to aarch64 got memleak 
```
Architecture:        aarch64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              8
On-line CPU(s) list: 0-7
Thread(s) per core:  1
Core(s) per socket:  4
Socket(s):           2
Vendor ID:           ARM
Model:               0
Model name:          Cortex-A73
Stepping:            r1p0
CPU max MHz:         2200.0000
CPU min MHz:         400.0000
BogoMIPS:            48.00
Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
```
valgrind --leak-check=summary lshw
```
==15574== HEAP SUMMARY:
==15574==     in use at exit: 64 bytes in 2 blocks
==15574==   total heap usage: 2,726,260 allocs, 2,726,258 frees, 404,418,666 bytes allocated
==15574== 
==15574== LEAK SUMMARY:
==15574==    definitely lost: 64 bytes in 2 blocks
==15574==    indirectly lost: 0 bytes in 0 blocks
==15574==      possibly lost: 0 bytes in 0 blocks
==15574==    still reachable: 0 bytes in 0 blocks
==15574==         suppressed: 0 bytes in 0 blocks
==15574== Rerun with --leak-check=full to see details of leaked memory
```
apply patch commit 956c8f56667751c4fb7e7fd3ed0003871c84431b
```
==15862== 
==15862== HEAP SUMMARY:
==15862==     in use at exit: 0 bytes in 0 blocks
==15862==   total heap usage: 2,726,260 allocs, 2,726,260 frees, 404,419,056 bytes allocated
==15862== 
==15862== All heap blocks were freed -- no leaks are possible
==15862== 
==15862== For counts of detected and suppressed errors, rerun with: -v
==15862== Use --track-origins=yes to see where uninitialised values come from
==15862== ERROR SUMMARY: 21857 errors from 32 contexts (suppressed: 0 from 0)
```