### PR TITLE
Add support for loongarch cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 lshw: HardWare LiSter for Linux
 ===============================
 
-lshw is a small tool to provide detailed information on the hardware configuration of the machine. It can report exact memory configuration, firmware version, mainboard configuration, CPU version and speed, cache configuration, bus speed, etc. on DMI-capable x86 or EFI (IA-64) systems and on some ARM and PowerPC machines (PowerMac G4 is known to work).
+lshw is a small tool to provide detailed information on the hardware configuration of the machine. It can report exact memory configuration, firmware version, mainboard configuration, CPU version and speed, cache configuration, bus speed, etc. on DMI-capable x86 or EFI (IA-64, LoongArch and others) systems and on some ARM and PowerPC machines (PowerMac G4 is known to work).
 
 Information can be output in plain text, XML or HTML.
 
@@ -14,7 +14,7 @@ Installation
 
  1. Requirements
    - Linux 2.4.x, 2.6.x, 3.x or 4.x (2.2.x might work, though)
-   - a PA-RISC-, Alpha-, IA-64- (Itanium-), PowerPC-, ARM- or x86- based machine
+   - a PA-RISC-, Alpha-, IA-64- (Itanium-), PowerPC-, LoongArch-, ARM- or x86- based machine
    - an ANSI (or close enough to ANSI compliance) C++ compiler (tested with g++ 2.95.4 and 3.x)
    - for the (optional) GTK+ graphical user interface, you will need a
 	complete GTK+ development environment (gtk3-devel on RedHat/Fedora derivatives)
@@ -43,7 +43,7 @@ Getting help
  1. the lshw home page is http://lshw.ezix.org/
  2. bug reports and feature requests: http://ezix.org/project/newticket?component=lshw
 
-   Please make sure you include enough information in your bug report: XML output from lshw is preferred over text or HTML, indicate the affected version of lshw, your platform (i386, x86-64, PA-RISC, PowerPC, etc.) and your distribution.
+   Please make sure you include enough information in your bug report: XML output from lshw is preferred over text or HTML, indicate the affected version of lshw, your platform (i386, x86-64, PA-RISC, PowerPC, LoongArch, etc.) and your distribution.
 
 NOTE TO DISTRIBUTIONS
 ---------------------

--- a/src/core/cpuinfo.cc
+++ b/src/core/cpuinfo.cc
@@ -276,6 +276,49 @@ static void cpuinfo_aarch64(hwNode & node,
     }
 }
 
+static void cpuinfo_loongarch64(hwNode & node,
+string id,
+string value)
+{
+
+  if (id == "processor")
+    currentcpu++;
+
+  hwNode *cpu = getcpu(node, currentcpu);
+
+  if (cpu)
+  {
+    cpu->claim(true);
+
+    if (id == "Model Name")
+      cpu->setProduct(value);
+
+    if (id == "CPU Revision")
+      cpu->setVersion(value);
+
+    if (id == "CPU MHz" && cpu->getSize() == 0)
+    {
+      double frequency = 0.0;
+
+      frequency = atof(value.c_str());
+      cpu->setSize((unsigned long long) (frequency * 1E6));
+    }
+    if (id == "Features")
+    {
+      while (value.length() > 0)
+      {
+        size_t pos = value.find(' ');
+        string capability = (pos==string::npos)?value:value.substr(0, pos);
+        cpu->addCapability(capability);
+        if (pos == string::npos)
+          value = "";
+        else
+          value = hw::strip(value.substr(pos));
+      }
+    }
+  }
+}
+
 static void cpuinfo_ia64(hwNode & node,
 string id,
 string value)
@@ -668,6 +711,10 @@ bool scan_cpuinfo(hwNode & n)
         else if (plat == "aarch64")
         {
           cpuinfo_aarch64(n, id, value);
+        }
+        else if (plat == "loongarch64")
+        {
+          cpuinfo_loongarch64(n, id, value);
         }
         else
         {


### PR DESCRIPTION
Add ```loongarch``` support, the new architecture launched by China's ```Loongson```. It can be compiled and run normally under ```loongarch``` architecture. 
[loongarch cpuinfo](https://github.com/torvalds/linux/blob/master/arch/loongarch/kernel/proc.c#L49-L64)