### PR TITLE
printing of non ascii characters in -html translated output

### DIFF
--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -482,10 +482,12 @@ string escape(const string & s)
 
   for (unsigned int i = 0; i < s.length(); i++)
     // #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+    // add negative value for accentuated or chinese character in po files
     if (s[i] == 0x9
         || s[i] == 0xA
         || s[i] == 0xD
-        || s[i] >= 0x20)
+        || s[i] >= 0x20
+        || s[i] <  0x00 )
       switch (s[i])
       {
         case '<':

--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -487,7 +487,7 @@ string escape(const string & s)
         || s[i] == 0xA
         || s[i] == 0xD
         || s[i] >= 0x20
-        || s[i] <  0x00 )
+        || s[i] <  0x0)
       switch (s[i])
       {
         case '<':


### PR DESCRIPTION
hi, 
a bug in printing -html and -xml output has been found on french ubuntu forum, reported on launchpad. I've found a quick fix and share it here. Hope I did right. 