### PR TITLE
Prefer max CPU frequency from /sys over DMI info

### DIFF
--- a/src/core/cpufreq.cc
+++ b/src/core/cpufreq.cc
@@ -68,7 +68,7 @@ bool scan_cpufreq(hwNode & node)
       cur = 1000*(unsigned long long)get_long("scaling_cur_freq");
       cpu->addCapability("cpufreq", "CPU Frequency scaling");
       if(cur) cpu->setSize(cur);
-      if(max>cpu->getCapacity()) cpu->setCapacity(max);
+      if(max) cpu->setCapacity(max);
       popd();
     }
     i++;


### PR DESCRIPTION
Currently, the first module to set the max CPU frequency (capacity) is `dmi`. The `cpufreq` module only overwrites this value if it determined a value greater than the one from DMI.

However, as the dmidecode man page [1] states:

> More often than not, information contained in the DMI tables is
> inaccurate, incomplete or simply wrong.

[1] https://linux.die.net/man/8/dmidecode

I can attest to that, insofar as many of the servers I manage report a hugely exaggerated max frequency in the DMI data, whereas the sysfs data from the `cpufreq` module is always correct.

With the current approach of only overwriting the value if it is greater than the one from DMI, these exaggerated values show up in the final output of `lshw`.

This commit always prefers the max CPU frequency value from the `cpufreq` module, unless it is `0` (i.e. failed to determine).