### PR TITLE
Fix unresolved reference when using optimization flag (-O2) against musl

### DIFF
--- a/src/core/osutils.cc
+++ b/src/core/osutils.cc
@@ -421,7 +421,7 @@ bool matches(const string & s, const string & pattern, int cflags)
 }
 
 
-string readlink(const string & path)
+string readsymlink(const string & path)
 {
   char buffer[PATH_MAX+1];
 

--- a/src/core/osutils.h
+++ b/src/core/osutils.h
@@ -12,7 +12,7 @@ std::string pwd();
 
 bool exists(const std::string & path);
 bool samefile(const std::string & path1, const std::string & path2);
-std::string readlink(const std::string & path);
+std::string readsymlink(const std::string & path);
 std::string realpath(const std::string & path);
 std::string dirname(const std::string & path);
 std::string shortname(const std::string & path);

--- a/src/core/parisc.cc
+++ b/src/core/parisc.cc
@@ -543,7 +543,7 @@ static bool scan_device(hwNode & node, string name = "")
       newnode.setBusInfo(guessBusInfo(name));
     if(exists("driver"))
     {
-      string driver = readlink("driver");
+      string driver = readsymlink("driver");
       size_t slash = driver.rfind("/");
       newnode.setConfig("driver", driver.substr(slash==driver.npos?0:slash+1));
       newnode.claim();

--- a/src/core/pci.cc
+++ b/src/core/pci.cc
@@ -1169,8 +1169,8 @@ bool scan_pci(hwNode & n)
         device->setBusInfo(devices[i]->d_name);
         if(exists(string(devices[i]->d_name)+"/driver"))
         {
-          string drivername = readlink(string(devices[i]->d_name)+"/driver");
-          string modulename = readlink(string(devices[i]->d_name)+"/driver/module");
+          string drivername = readsymlink(string(devices[i]->d_name)+"/driver");
+          string modulename = readsymlink(string(devices[i]->d_name)+"/driver/module");
 
           device->setConfig("driver", shortname(drivername));
           if(exists(modulename))

--- a/src/core/sysfs.cc
+++ b/src/core/sysfs.cc
@@ -251,7 +251,7 @@ string entry::driver() const
   string driverlink = This->devpath + "/driver";
   if (!exists(driverlink))
     return "";
-  return shortname(readlink(driverlink));
+  return shortname(readsymlink(driverlink));
 }
 
 


### PR DESCRIPTION
In case you want to fortify headers you get errors like this:
```
/usr/include/fortify/unistd.h:156:1: error: reference to overloaded function could not be resolved; did you mean to call it?
  156 | _FORTIFY_FN(readlink) ssize_t readlink(const char *__p,
```
This is due of the `readlink` function from `osutils.h` that conflicts with `readlink` from `unistd.h`. To avoid that I propose to simply rename `string readlink` to `string readsymlink`.
To test, just add `-O2` in the `src/Makefile` to `CXXFLAGS`