### PR TITLE
lshw: Add accelerator hardware class for PCI class 0x12 devices

### DIFF
--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -231,6 +231,9 @@ const char *hwNode::getClassName() const
       case volume:
         return "volume";
 
+      case accelerator:
+       return "accelerator";
+
       default:
         return "generic";
     }

--- a/src/core/hw.h
+++ b/src/core/hw.h
@@ -28,7 +28,8 @@ namespace hw
     communication,
     power,
     volume,
-    generic
+    generic,
+    accelerator
   } hwClass;
 
   typedef enum { none, iomem, ioport, mem, irq, dma }

--- a/src/core/pci.cc
+++ b/src/core/pci.cc
@@ -179,6 +179,9 @@ __ID("@(#) $Id$");
 #define PCI_CLASS_SERIAL_USB         0x0c03
 #define PCI_CLASS_SERIAL_FIBER       0x0c04
 
+#define PCI_BASE_CLASS_ACCELERATOR   0x12
+#define PCI_CLASS_ACCELERATOR       0x1200
+
 #define PCI_CLASS_OTHERS             0xff
 
 #define PCI_ADDR_MEM_MASK (~(pciaddr_t) 0xf)
@@ -393,6 +396,8 @@ static const char *get_class_name(unsigned int c)
       return "processor";
     case PCI_BASE_CLASS_SERIAL:
       return "serial";
+    case PCI_BASE_CLASS_ACCELERATOR:
+      return "accelerator";
   }
 
   return "generic";
@@ -907,6 +912,10 @@ static hwNode *scan_pci_dev(struct pci_dev &d, hwNode & n)
           case PCI_BASE_CLASS_INPUT:
             deviceclass = hw::input;
             break;
+         case PCI_BASE_CLASS_ACCELERATOR:
+               deviceclass = hw::accelerator;
+               deviceicon = "accelerator";
+               break;
           case PCI_BASE_CLASS_PROCESSOR:
             deviceclass = hw::processor;
             break;


### PR DESCRIPTION
- Add hw::accelerator enum and class mapping
- Map PCI class 0x12 to accelerator instead of generic
- Enable 'lshw -class accelerator' filtering

Signed-off-by: Sathvika Vasireddy <sv@linux.ibm.com>