### PR TITLE
get the hints, subvendor and subdevice ids for pci devices in json output mode

### DIFF
--- a/src/core/hw.cc
+++ b/src/core/hw.cc
@@ -1449,6 +1449,24 @@ string hwNode::asJSON(unsigned level)
       out << "\"";
     }
 
+    if (getSubProduct() != "")
+    {
+      out << "," << endl;
+      out << spaces(2*level+2);
+      out << "\"subproduct\" : \"";
+      out << escapeJSON(getSubProduct());
+      out << "\"";
+    }
+
+    if (getSubVendor() != "")
+    {
+      out << "," << endl;
+      out << spaces(2*level+2);
+      out << "\"subvendor\" : \"";
+      out << escapeJSON(getSubVendor());
+      out << "\"";
+    }
+
     if (getPhysId() != "")
     {
       out << "," << endl;
@@ -1651,6 +1669,23 @@ string hwNode::asJSON(unsigned level)
       out << "</resources>" << endl;
     }
     resources.clear();
+
+    vector < string > hints = getHints();
+    if (hints.size() > 0)
+    {
+      out << "," << endl;
+      out << spaces(2*level+2);
+      out << "\"hints\" : {" << endl;
+      for (unsigned int j = 0; j < hints.size(); j++)
+      {
+        if(j) out << "," << endl;
+        out << spaces(2*level+4);
+        out << "\"" << escapeJSON(hints[j]) << "\" : \"" << escapeJSON(getHint(hints[j]).asString()) << "\"";
+      }
+      out << endl << spaces(2*level+2);
+      out << "}";
+    }
+    hints.clear();
   }
 
   if(!::enabled("output:list") && countChildren()>0)

--- a/src/core/pci.cc
+++ b/src/core/pci.cc
@@ -831,7 +831,7 @@ static hwNode *scan_pci_dev(struct pci_dev &d, hwNode & n)
         if (subsys_v != 0 || subsys_d != 0)
         {
           host.setSubVendor(get_device_description(subsys_v)+(enabled("output:numeric")?" ["+tohex(subsys_v)+"]":""));
-          host.setSubProduct(get_device_description(subsys_v, subsys_d)+(enabled("output:numeric")?" ["+tohex(subsys_v)+":"+tohex(subsys_d)+"]":""));
+          host.setSubProduct(get_device_description(d.vendor_id, d.device_id, subsys_v, subsys_d)+(enabled("output:numeric")?" ["+tohex(subsys_v)+":"+tohex(subsys_d)+"]":""));
         }
         host.setHandle(pci_bushandle(d.bus, d.domain));
         host.setVersion(revision);
@@ -1002,7 +1002,7 @@ static hwNode *scan_pci_dev(struct pci_dev &d, hwNode & n)
           if (subsys_v != 0 || subsys_d != 0)
           {
             device->setSubVendor(get_device_description(subsys_v)+(enabled("output:numeric")?" ["+tohex(subsys_v)+"]":""));
-            device->setSubProduct(get_device_description(subsys_v, subsys_d)+(enabled("output:numeric")?" ["+tohex(subsys_v)+":"+tohex(subsys_d)+"]":""));
+            device->setSubProduct(get_device_description(d.vendor_id, d.device_id, subsys_v, subsys_d)+(enabled("output:numeric")?" ["+tohex(subsys_v)+":"+tohex(subsys_d)+"]":""));
           }
           if (cmd & PCI_COMMAND_MASTER)
             device->addCapability("bus master", "bus mastering");


### PR DESCRIPTION
- mimic what is done for the xml output
- fix subsystem lookup from the subvendor and subdevice