### PR TITLE
sanitize: mask NVMe/disk device-unique identifiers

### DIFF
--- a/src/core/nvme.cc
+++ b/src/core/nvme.cc
@@ -5,6 +5,7 @@
 #include "nvme.h"
 #include "disk.h"
 #include "heuristics.h"
+#include "options.h"
 
 #include <vector>
 #include <iostream>
@@ -36,7 +37,7 @@ bool scan_nvme(hwNode & n)
     device->setProduct(e.string_attr("model"));
     device->setSerial(e.string_attr("serial"));
     device->setVersion(e.string_attr("firmware_rev"));
-    device->setConfig("nqn",e.string_attr("subsysnqn"));
+    device->setConfig("nqn",::enabled("output:sanitize")?REMOVED:e.string_attr("subsysnqn"));
     device->setConfig("state",e.string_attr("state"));
     device->setModalias(e.modalias());
 
@@ -59,7 +60,7 @@ bool scan_nvme(hwNode & n)
 	      ns.setLogicalName(n.name().erase(indexc, indexn - indexc));
       } else
 	      ns.setLogicalName(n.name());
-      ns.setConfig("wwid",n.string_attr("wwid"));
+      ns.setConfig("wwid",::enabled("output:sanitize")?REMOVED:n.string_attr("wwid"));
       scan_disk(ns);
       device->addChild(ns);
     }

--- a/src/core/partitions.cc
+++ b/src/core/partitions.cc
@@ -20,6 +20,7 @@
 #include "lvm.h"
 #include "volumes.h"
 #include "osutils.h"
+#include "options.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <cstring>
@@ -750,9 +751,9 @@ static bool detect_gpt(source & s, hwNode & n)
 
   n.addCapability("gpt-"+string(gpt_version), "GUID Partition Table version "+string(gpt_version));
   n.addHint("partitions", gpt_header.NumberOfPartitionEntries);
-  n.setConfig("guid", tostring(gpt_header.DiskGUID));
-  n.setHandle("GUID:" + tostring(gpt_header.DiskGUID));
-  n.addHint("guid", tostring(gpt_header.DiskGUID));
+  n.setConfig("guid",::enabled("output:sanitize")?REMOVED:tostring(gpt_header.DiskGUID));
+  n.setHandle(::enabled("output:sanitize")?"GUID:":"GUID:" + tostring(gpt_header.DiskGUID));
+  n.addHint("guid",::enabled("output:sanitize")?REMOVED:tostring(gpt_header.DiskGUID));
 
   partitions = (uint8_t*)malloc(gpt_header.NumberOfPartitionEntries * gpt_header.SizeOfPartitionEntry + BLOCKSIZE);
   if(!partitions)


### PR DESCRIPTION
The -sanitize flag masks serial numbers and IP addresses but misses three device-unique identifiers exposed via configuration keys:
- nqn (NVMe Qualified Name, contains device serial)
- wwid (NVMe World Wide ID, EUI-64)
- guid (GPT disk GUID)

These are the same sensitivity level as serial numbers already masked. Apply the same pattern used for IP sanitization in network.cc.