### PR TITLE
spd: include <cstdlib> for free()

### DIFF
--- a/src/core/spd.cc
+++ b/src/core/spd.cc
@@ -10,6 +10,7 @@
 #include <dirent.h>
 #include <stdio.h>
 #include <cstring>
+#include <cstdlib>
 
 __ID("@(#) $Id$");
 


### PR DESCRIPTION
`scan_eeproms()` in `src/core/spd.cc` calls `free()`, but the file never includes `<cstdlib>` (nor `<stdlib.h>`). It has only ever compiled because the declaration was reachable transitively through one of the other headers.

Newer C++ standard libraries are trimming those transitive includes. With LLVM 22 / libc++ the build now fails:

```
src/core/spd.cc:199:5: error: use of undeclared identifier 'free'
  199 |     free(namelist[i]);
      |     ^
```

Fix is to include `<cstdlib>` explicitly, next to the existing `<cstring>` include:

```diff
 #include <stdio.h>
 #include <cstring>
+#include <cstdlib>
```

No functional change — one added include. Verified that `src/core/spd.cc` still compiles clean with GCC (`g++ -fsyntax-only`), and the added include is what unbreaks the libc++ 22 build.
